### PR TITLE
Reschedule client to another session

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,5 +187,5 @@ _Allow the creation of sessions and tagging of its associated client_
 |Adding Gym Session |`sadd s/SESSIONTYPE dt/DATETIME dur/DURATION g/GYM_NAME` | `sadd Upper Body dt/this Thursday 4pm dur/2hr g/UTown Gym`|
 |Assign a Client to Gym Session  |`sched add c/CLIENT_INDEX s/SESSION_INDEX`| `sched add c/1 s/3`|
 |Unassign a Client to Gym Session |`sched rm c/CLIENT_INDEX s/SESSION_INDEX`  | `sched rm c/2 s/3` |
-|Updating Session Info |`sedit INDEX [s/SESSIONTYPE] [dt/DATETIME] [dur/DURATION] [g/GYM_NAME]`| `sedit 1 dt/this Friday 6pm`|
+|Updating Session Info |`sedit INDEX [g/GYM] [ex/EXERCISE_TYPE] [at/START_TIME] [t/DURATION]`| `sedit 1 g/Machoman at/29/09/2020 1600 t/120`
 |Deleting a Session |`sdel INDEX` | `sdel 1`|

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -185,7 +185,7 @@ _Allow the creation of sessions and tagging of its associated client_
 |View a Client's Full Profile | `cview INDEX` | `cview 1`|
 |Find Client by Name | `cfind KEYWORD [MORE_KEYWORDS]`| `cfind John Doe`|
 |Adding Gym Session |`sadd s/SESSIONTYPE dt/DATETIME dur/DURATION g/GYM_NAME` | `sadd Upper Body dt/this Thursday 4pm dur/2hr g/UTown Gym`|
-|Assign a Client to Gym Session  |`sched add c/CLIENT_INDEX s/SESSION_INDEX`| `sched add c/1 s/3`|
-|Unassign a Client to Gym Session |`sched rm c/CLIENT_INDEX s/SESSION_INDEX`  | `sched rm c/2 s/3` |
-|Updating Session Info |`sedit INDEX [g/GYM] [ex/EXERCISE_TYPE] [at/START_TIME] [t/DURATION]`| `sedit 1 g/Machoman at/29/09/2020 1600 t/120`
+|Assign a Client to Gym Session  |`schedule c/CLIENT_INDEX s/SESSION_INDEX`| `schedule c/1 s/3`|
+|Unassign a Client to Gym Session |`deschedule c/CLIENT_INDEX s/SESSION_INDEX`  | `deschedule c/2 s/3` |
+|Edit a Client to Gym Session |`reschedule c/CLIENT_INDEX s/SESSION_INDEX`  | `reschedule c/2 s/3` |Updating Session Info |`sedit INDEX [g/GYM] [ex/EXERCISE_TYPE] [at/START_TIME] [t/DURATION]`| `sedit 1 g/Machoman at/29/09/2020 1600 t/120`
 |Deleting a Session |`sdel INDEX` | `sdel 1`|

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The Client index provided is invalid";
+    public static final String MESSAGE_INVALID_SESSION_DISPLAYED_INDEX = "The Session index provided is invalid";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d Clients listed!";
 
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The Client index provided is invalid";
     public static final String MESSAGE_INVALID_SESSION_DISPLAYED_INDEX = "The Session index provided is invalid";
+    public static final String MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX = "The Schedule index provided is invalid";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d Clients listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
@@ -1,0 +1,174 @@
+package seedu.address.logic.commands.schedule;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_CLIENT_INDEX;
+import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_SESSION_INDEX;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SCHEDULES;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.model.Model;
+import seedu.address.model.client.Client;
+import seedu.address.model.schedule.Schedule;
+import seedu.address.model.session.Session;
+
+/**
+ * Edits the details of an existing Client in the address book.
+ */
+public class RescheduleCommand extends Command {
+
+    public static final String COMMAND_WORD = "reschedule";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Reschedule a client with another session. "
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + PREFIX_SESSION_INDEX + "SESSION "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_SESSION_INDEX + "1 ";
+
+    public static final String MESSAGE_EDIT_SCHEDULE_SUCCESS = "Rescheduled : \n%1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_SCHEDULE = "This Schedule overlaps with an existing Schedule";
+
+    private final Index index;
+    private final RescheduleDescriptor editRescheduleDescriptor;
+
+    /**
+     * @param index of the Schedule in the filtered schedule list to edit
+     * @param editRescheduleDescriptor details to edit the schedule with
+     */
+    public RescheduleCommand(Index index, RescheduleDescriptor editRescheduleDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editRescheduleDescriptor);
+
+        this.index = index;
+        this.editRescheduleDescriptor = new RescheduleDescriptor(editRescheduleDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Schedule> lastShownList = model.getFilteredScheduleList();
+        List<Session> lastShownSessionList = model.getFilteredSessionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
+        }
+
+        Schedule scheduleToEdit = lastShownList.get(index.getZeroBased());
+        Schedule editedSchedule = createEditedSchedule(scheduleToEdit, editRescheduleDescriptor,
+                lastShownSessionList);
+
+        if (!scheduleToEdit.isExisting(editedSchedule) && model.hasSchedule(editedSchedule)) {
+            throw new CommandException(MESSAGE_DUPLICATE_SCHEDULE);
+        }
+
+        model.setSchedule(scheduleToEdit, editedSchedule);
+        model.updateFilteredScheduleList(PREDICATE_SHOW_ALL_SCHEDULES);
+        return new CommandResult(String.format(MESSAGE_EDIT_SCHEDULE_SUCCESS, editedSchedule));
+    }
+
+    /**
+     * Creates and returns a {@code Schedule} with the details of {@code scheduleToEdit}
+     * edited with {@code editRescheduleDescriptor}.
+     */
+    private static Schedule createEditedSchedule(Schedule scheduleToEdit, RescheduleDescriptor rescheduleDescriptor,
+                                                 List<Session> lastShownSessionList) {
+        assert scheduleToEdit != null;
+
+        Client client = scheduleToEdit.getClient();
+        Session session = rescheduleDescriptor.getSessionIndex() == null
+                ? scheduleToEdit.getSession()
+                : lastShownSessionList.get(rescheduleDescriptor.getSessionIndex().get().getZeroBased());
+
+        return new Schedule(client, session);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RescheduleCommand)) {
+            return false;
+        }
+
+        // state check
+        RescheduleCommand e = (RescheduleCommand) other;
+        return index.equals(e.index)
+                && editRescheduleDescriptor.equals(e.editRescheduleDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the Schedule with. Each non-empty field value will replace the
+     * corresponding field value of the Schedule.
+     */
+    public static class RescheduleDescriptor {
+        private Index clientIndex;
+        private Index sessionIndex;
+
+        public RescheduleDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public RescheduleDescriptor(RescheduleDescriptor toCopy) {
+            setClientIndex(toCopy.clientIndex);
+            setSessionIndex(toCopy.sessionIndex);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(clientIndex, sessionIndex);
+        }
+
+        public void setClientIndex(Index clientIndex) {
+            this.clientIndex = clientIndex;
+        }
+
+        public Optional<Index> getClientIndex() {
+            return Optional.ofNullable(clientIndex);
+        }
+
+        public void setSessionIndex(Index sessionIndex) {
+            this.sessionIndex = sessionIndex;
+        }
+
+        public Optional<Index> getSessionIndex() {
+            return Optional.ofNullable(sessionIndex);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof RescheduleDescriptor)) {
+                return false;
+            }
+
+            // state check
+            RescheduleDescriptor e = (RescheduleDescriptor) other;
+
+            return getClientIndex().equals(e.getClientIndex())
+                    && getSessionIndex().equals(e.getSessionIndex());
+        }
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
@@ -38,28 +38,35 @@ public class RescheduleCommand extends Command {
     public static final String MESSAGE_DUPLICATE_SCHEDULE = "This Schedule overlaps with an existing Schedule";
 
     private final Index index;
+    private final Index sessionIndex;
     private final RescheduleDescriptor editRescheduleDescriptor;
 
     /**
      * @param index of the Schedule in the filtered schedule list to edit
      * @param editRescheduleDescriptor details to edit the schedule with
      */
-    public RescheduleCommand(Index index, RescheduleDescriptor editRescheduleDescriptor) {
+    public RescheduleCommand(Index index, Index sessionIndex, RescheduleDescriptor editRescheduleDescriptor) {
         requireNonNull(index);
         requireNonNull(editRescheduleDescriptor);
 
         this.index = index;
+        this.sessionIndex = sessionIndex;
         this.editRescheduleDescriptor = new RescheduleDescriptor(editRescheduleDescriptor);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         List<Schedule> lastShownList = model.getFilteredScheduleList();
         List<Session> lastShownSessionList = model.getFilteredSessionList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
+        }
+
+        if (sessionIndex.getZeroBased() >= lastShownSessionList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
         }
 
         Schedule scheduleToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
@@ -35,19 +35,20 @@ public class RescheduleCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_SCHEDULE = "This Schedule overlaps with an existing Schedule";
 
-    private final Index index;
+    private final Index scheduleIndex;
     private final Index sessionIndex;
     private final RescheduleDescriptor editRescheduleDescriptor;
 
     /**
-     * @param index of the Schedule in the filtered schedule list to edit
+     * @param scheduleIndex of the Schedule in the filtered schedule list to edit
+     * @param sessionIndex of the Session in the filtered session list to edit
      * @param editRescheduleDescriptor details to edit the schedule with
      */
-    public RescheduleCommand(Index index, Index sessionIndex, RescheduleDescriptor editRescheduleDescriptor) {
-        requireNonNull(index);
+    public RescheduleCommand(Index scheduleIndex, Index sessionIndex, RescheduleDescriptor editRescheduleDescriptor) {
+        requireNonNull(scheduleIndex);
         requireNonNull(editRescheduleDescriptor);
 
-        this.index = index;
+        this.scheduleIndex = scheduleIndex;
         this.sessionIndex = sessionIndex;
         this.editRescheduleDescriptor = new RescheduleDescriptor(editRescheduleDescriptor);
     }
@@ -59,7 +60,7 @@ public class RescheduleCommand extends Command {
         List<Schedule> lastShownList = model.getFilteredScheduleList();
         List<Session> lastShownSessionList = model.getFilteredSessionList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (scheduleIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
         }
 
@@ -67,7 +68,7 @@ public class RescheduleCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
         }
 
-        Schedule scheduleToEdit = lastShownList.get(index.getZeroBased());
+        Schedule scheduleToEdit = lastShownList.get(scheduleIndex.getZeroBased());
         Schedule editedSchedule = createEditedSchedule(scheduleToEdit, editRescheduleDescriptor,
                 lastShownSessionList);
 
@@ -110,7 +111,7 @@ public class RescheduleCommand extends Command {
 
         // state check
         RescheduleCommand e = (RescheduleCommand) other;
-        return index.equals(e.index)
+        return scheduleIndex.equals(e.scheduleIndex)
                 && editRescheduleDescriptor.equals(e.editRescheduleDescriptor);
     }
 

--- a/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/RescheduleCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands.schedule;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_CLIENT_INDEX;
 import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_SESSION_INDEX;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SCHEDULES;
 
@@ -14,7 +13,6 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 import seedu.address.model.schedule.Schedule;

--- a/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
@@ -1,0 +1,186 @@
+package seedu.address.logic.commands.session;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.session.Session;
+import seedu.address.model.session.Gym;
+import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Interval;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
+
+public class EditSessionCommand extends Command {
+
+    public static final String COMMAND_WORD = "sedit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the Session identified "
+            + "by the index number used in the displayed Session list.\n"
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_GYM + "GYM] "
+            + "[" + PREFIX_EXERCISE_TYPE + "EXERCISE_TYPE] "
+            + "[" + PREFIX_START_TIME + "START_TIME] "
+            + "[" + PREFIX_DURATION + "DURATION]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_GYM + "Machoman "
+            + PREFIX_START_TIME + "29/09/2020 1600 "
+            + PREFIX_DURATION + "120 ";
+
+    public static final String MESSAGE_EDIT_SESSION_SUCCESS = "Edited Session: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_SESSION = "This Session already exists in the FitEgo.";
+
+    private final Index index;
+    private final EditSessionDescriptor editSessionDescriptor;
+
+    /**
+     * @param index of the Session in the filtered session list to edit
+     * @param editSessionDescriptor details to edit the session with
+     */
+    public EditSessionCommand(Index index, EditSessionDescriptor editSessionDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editSessionDescriptor);
+
+        this.index = index;
+        this.editSessionDescriptor = new EditSessionDescriptor(editSessionDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Session> lastShownList = model.getFilteredSessionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+        }
+
+        Session sessionToEdit = lastShownList.get(index.getZeroBased());
+        Session editedSession = createEditedSession(sessionToEdit, editSessionDescriptor);
+
+        if (!sessionToEdit.isExisting(editedSession) && model.hasSession(editedSession)) {
+            throw new CommandException(MESSAGE_DUPLICATE_SESSION);
+        }
+
+        model.setSession(sessionToEdit, editedSession);
+        model.updateFilteredSessionList(PREDICATE_SHOW_ALL_SESSIONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_SESSION_SUCCESS, editedSession));
+    }
+
+    /**
+     * Creates and returns a {@code Session} with the details of {@code SessionToEdit}
+     * edited with {@code editSessionDescriptor}.
+     */
+    private static Session createEditedSession(Session sessionToEdit, EditSessionDescriptor editSessionDescriptor) {
+        assert sessionToEdit != null;
+
+        Gym updatedGym = editSessionDescriptor.getGym().orElse(sessionToEdit.getGym());
+        ExerciseType updatedExerciseType = editSessionDescriptor.getExerciseType().orElse(sessionToEdit.getExerciseType());
+        Interval updatedInterval = editSessionDescriptor.getInterval().orElse(sessionToEdit.getInterval());
+
+        return new Session(sessionToEdit.getId(), updatedGym, updatedExerciseType, updatedInterval);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditSessionCommand)) {
+            return false;
+        }
+
+        // state check
+        EditSessionCommand e = (EditSessionCommand) other;
+        return index.equals(e.index)
+                && editSessionDescriptor.equals(e.editSessionDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the Session with. Each non-empty field value will replace the
+     * corresponding field value of the Session.
+     */
+    public static class EditSessionDescriptor {
+        private Gym gym;
+        private ExerciseType exerciseType;
+        private Interval interval;
+
+        public EditSessionDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditSessionDescriptor(EditSessionDescriptor toCopy) {
+            setGym(toCopy.gym);
+            setExerciseType(toCopy.exerciseType);
+            setInterval(toCopy.interval);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(gym, exerciseType, interval);
+        }
+
+        public void setGym(Gym gym) {
+            this.gym = gym;
+        }
+
+        public Optional<Gym> getGym() {
+            return Optional.ofNullable(gym);
+        }
+
+        public void setExerciseType(ExerciseType exerciseType) {
+            this.exerciseType = exerciseType;
+        }
+
+        public Optional<ExerciseType> getExerciseType() {
+            return Optional.ofNullable(exerciseType);
+        }
+
+        public void setInterval(Interval interval) {
+            this.interval = interval;
+        }
+
+        public Optional<Interval> getInterval() {
+            return Optional.ofNullable(interval);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditSessionDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditSessionDescriptor e = (EditSessionDescriptor) other;
+
+            return getGym().equals(e.getGym())
+                    && getExerciseType().equals(e.getExerciseType())
+                    && getInterval().equals(e.getInterval());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
@@ -1,5 +1,12 @@
 package seedu.address.logic.commands.session;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -7,20 +14,13 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.session.Session;
-import seedu.address.model.session.Gym;
 import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Gym;
 import seedu.address.model.session.Interval;
+import seedu.address.model.session.Session;
 
 import java.util.List;
 import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
 
 public class EditSessionCommand extends Command {
 
@@ -87,7 +87,8 @@ public class EditSessionCommand extends Command {
         assert sessionToEdit != null;
 
         Gym updatedGym = editSessionDescriptor.getGym().orElse(sessionToEdit.getGym());
-        ExerciseType updatedExerciseType = editSessionDescriptor.getExerciseType().orElse(sessionToEdit.getExerciseType());
+        ExerciseType updatedExerciseType = editSessionDescriptor
+                .getExerciseType().orElse(sessionToEdit.getExerciseType());
         Interval updatedInterval = editSessionDescriptor.getInterval().orElse(sessionToEdit.getInterval());
 
         return new Session(sessionToEdit.getId(), updatedGym, updatedExerciseType, updatedInterval);

--- a/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
@@ -7,6 +7,8 @@ import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
 
+import java.util.List;
+import java.util.Optional;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -18,9 +20,6 @@ import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
 import seedu.address.model.session.Interval;
 import seedu.address.model.session.Session;
-
-import java.util.List;
-import java.util.Optional;
 
 public class EditSessionCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/session/EditSessionCommand.java
@@ -9,6 +9,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
 
 import java.util.List;
 import java.util.Optional;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -63,6 +63,7 @@ public class AddressBookParser {
 
         //Session-Related Commands
         commandMapper.put(AddSessionCommand.COMMAND_WORD, (args) -> new AddSessionCommandParser().parse(args));
+        commandMapper.put(EditSessionCommand.COMMAND_WORD, (args) -> new EditSessionCommandParser().parse(args));
 
         //Schedule-Related Commands
         commandMapper.put(AddScheduleCommand.COMMAND_WORD, (args) -> new AddScheduleCommandParser().parse(args));
@@ -89,39 +90,6 @@ public class AddressBookParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
-        case FindClientCommand.COMMAND_WORD:
-            return new FindClientCommandParser().parse(arguments);
-
-        case ViewClientCommand.COMMAND_WORD:
-            return new ViewClientCommandParser().parse(arguments);
-
-        case ListClientCommand.COMMAND_WORD:
-            return new ListClientCommand();
-
-        /*
-         * Session commands
-         */
-
-        case AddSessionCommand.COMMAND_WORD:
-            return new AddSessionCommandParser().parse(arguments);
-
-        case EditSessionCommand.COMMAND_WORD:
-            return new EditSessionCommandParser().parse(arguments);
-
-        /*
-         * General commands
-         */
-
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
-
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
-
-        default:
         if (commandMapper.containsKey(commandWord)) {
             return commandMapper.get(commandWord).apply(arguments);
         } else {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.client.FindClientCommand;
 import seedu.address.logic.commands.client.ListClientCommand;
 import seedu.address.logic.commands.client.ViewClientCommand;
 import seedu.address.logic.commands.schedule.AddScheduleCommand;
+import seedu.address.logic.commands.schedule.RescheduleCommand;
 import seedu.address.logic.commands.session.AddSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.parser.client.AddClientCommandParser;
@@ -27,6 +28,7 @@ import seedu.address.logic.parser.client.FindClientCommandParser;
 import seedu.address.logic.parser.client.ViewClientCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.schedule.AddScheduleCommandParser;
+import seedu.address.logic.parser.schedule.RescheduleCommandParser;
 import seedu.address.logic.parser.session.AddSessionCommandParser;
 import seedu.address.logic.parser.session.EditSessionCommandParser;
 
@@ -67,6 +69,7 @@ public class AddressBookParser {
 
         //Schedule-Related Commands
         commandMapper.put(AddScheduleCommand.COMMAND_WORD, (args) -> new AddScheduleCommandParser().parse(args));
+        commandMapper.put(RescheduleCommand.COMMAND_WORD, (args) -> new RescheduleCommandParser().parse(args));
 
         //Common-Application Commands
         commandMapper.put(ClearCommand.COMMAND_WORD, (args) -> new ClearCommand());

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.client.FindClientCommand;
 import seedu.address.logic.commands.client.ListClientCommand;
 import seedu.address.logic.commands.client.ViewClientCommand;
 import seedu.address.logic.commands.session.AddSessionCommand;
+import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.parser.client.AddClientCommandParser;
 import seedu.address.logic.parser.client.DeleteClientCommandParser;
 import seedu.address.logic.parser.client.EditClientCommandParser;
@@ -24,6 +25,7 @@ import seedu.address.logic.parser.client.FindClientCommandParser;
 import seedu.address.logic.parser.client.ViewClientCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.session.AddSessionCommandParser;
+import seedu.address.logic.parser.session.EditSessionCommandParser;
 
 /**
  * Parses user input.
@@ -80,6 +82,9 @@ public class AddressBookParser {
 
         case AddSessionCommand.COMMAND_WORD:
             return new AddSessionCommandParser().parse(arguments);
+
+        case EditSessionCommand.COMMAND_WORD:
+            return new EditSessionCommandParser().parse(arguments);
 
         /*
          * General commands

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.client.ListClientCommand;
 import seedu.address.logic.commands.client.ViewClientCommand;
 import seedu.address.logic.commands.schedule.AddScheduleCommand;
 import seedu.address.logic.commands.session.AddSessionCommand;
+import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.parser.client.AddClientCommandParser;
 import seedu.address.logic.parser.client.DeleteClientCommandParser;
 import seedu.address.logic.parser.client.EditClientCommandParser;
@@ -27,6 +28,7 @@ import seedu.address.logic.parser.client.ViewClientCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.schedule.AddScheduleCommandParser;
 import seedu.address.logic.parser.session.AddSessionCommandParser;
+import seedu.address.logic.parser.session.EditSessionCommandParser;
 
 /**
  * Parses user input.
@@ -61,6 +63,7 @@ public class AddressBookParser {
 
         //Session-Related Commands
         commandMapper.put(AddSessionCommand.COMMAND_WORD, (args) -> new AddSessionCommandParser().parse(args));
+        commandMapper.put(EditSessionCommand.COMMAND_WORD, (args) -> new EditSessionCommandParser().parse(args));
 
         //Schedule-Related Commands
         commandMapper.put(AddScheduleCommand.COMMAND_WORD, (args) -> new AddScheduleCommandParser().parse(args));

--- a/src/main/java/seedu/address/logic/parser/schedule/RescheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/schedule/RescheduleCommandParser.java
@@ -2,21 +2,15 @@ package seedu.address.logic.parser.schedule;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_CLIENT_INDEX;
 import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_SESSION_INDEX;
 
-import java.util.stream.Stream;
-
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.schedule.RescheduleCommand;
 import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class RescheduleCommandParser implements Parser<RescheduleCommand> {

--- a/src/main/java/seedu/address/logic/parser/schedule/RescheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/schedule/RescheduleCommandParser.java
@@ -40,11 +40,6 @@ public class RescheduleCommandParser implements Parser<RescheduleCommand> {
                     RescheduleCommand.MESSAGE_USAGE), pe);
         }
 
-//        if (ParserUtil.parseIndex(argMultimap.getValue(PREFIX_SESSION_INDEX).get()
-//                >= lastShownSessionList.size())) {
-//            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
-//        }
-
         RescheduleDescriptor editScheduleDescriptor = new RescheduleDescriptor();
 
         if (argMultimap.getValue(PREFIX_SESSION_INDEX).isPresent()) {
@@ -56,7 +51,8 @@ public class RescheduleCommandParser implements Parser<RescheduleCommand> {
             throw new ParseException(RescheduleCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new RescheduleCommand(index, editScheduleDescriptor);
+        return new RescheduleCommand(index, ParserUtil.parseIndex(argMultimap.getValue(PREFIX_SESSION_INDEX).get()),
+                editScheduleDescriptor);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/schedule/RescheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/schedule/RescheduleCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser.schedule;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_CLIENT_INDEX;
+import static seedu.address.logic.parser.schedule.CliSyntax.PREFIX_SESSION_INDEX;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.schedule.RescheduleCommand;
+import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class RescheduleCommandParser implements Parser<RescheduleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the RescheduleCommand
+     * and returns an RescheduleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RescheduleCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_SESSION_INDEX);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RescheduleCommand.MESSAGE_USAGE), pe);
+        }
+
+//        if (ParserUtil.parseIndex(argMultimap.getValue(PREFIX_SESSION_INDEX).get()
+//                >= lastShownSessionList.size())) {
+//            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+//        }
+
+        RescheduleDescriptor editScheduleDescriptor = new RescheduleDescriptor();
+
+        if (argMultimap.getValue(PREFIX_SESSION_INDEX).isPresent()) {
+            editScheduleDescriptor
+                    .setSessionIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_SESSION_INDEX).get()));
+        }
+
+        if (!editScheduleDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(RescheduleCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new RescheduleCommand(index, editScheduleDescriptor);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -1,11 +1,11 @@
 package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
-import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
+import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;
@@ -13,7 +14,6 @@ import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
-import static java.util.Objects.requireNonNull;
 
 public class EditSessionCommandParser implements Parser<EditSessionCommand> {
     /**

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.parser.session;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
@@ -8,11 +14,6 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
 
 public class EditSessionCommandParser implements Parser<EditSessionCommand> {
     /**

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser.session;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser.session;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.session.EditSessionCommand;
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
+
+public class EditSessionCommandParser implements Parser<EditSessionCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditSessionCommand
+     * and returns an EditSessionCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditSessionCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_GYM, PREFIX_EXERCISE_TYPE, PREFIX_START_TIME, PREFIX_DURATION);
+
+        Index index;
+
+        try {
+            index = SessionParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditSessionCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditSessionDescriptor editSessionDescriptor = new EditSessionDescriptor();
+        if (argMultimap.getValue(PREFIX_GYM).isPresent()) {
+            editSessionDescriptor.setGym(SessionParserUtil.parseGym(argMultimap.getValue(PREFIX_GYM).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EXERCISE_TYPE).isPresent()) {
+            editSessionDescriptor
+                    .setExerciseType(SessionParserUtil
+                            .parseExerciseType(argMultimap.getValue(PREFIX_EXERCISE_TYPE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_START_TIME).isPresent() && argMultimap.getValue(PREFIX_DURATION).isPresent()) {
+            editSessionDescriptor
+                    .setInterval(SessionParserUtil.parseInterval(argMultimap.getValue(PREFIX_START_TIME).get(),
+                                    argMultimap.getValue(PREFIX_DURATION).get()));
+        }
+
+        if (!editSessionDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditSessionCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditSessionCommand(index, editSessionDescriptor);
+    }
+
+}

--- a/src/main/java/seedu/address/model/session/Interval.java
+++ b/src/main/java/seedu/address/model/session/Interval.java
@@ -30,7 +30,7 @@ public class Interval {
      */
     public Interval(LocalDateTime start, int duration) {
         requireNonNull(start);
-        checkArgument(isValidInterval(duration), MESSAGE_DATE_TIME_CONSTRAINTS);
+        checkArgument(isValidInterval(duration), MESSAGE_CONSTRAINTS);
         this.start = start;
         this.durationInMinutes = duration;
     }

--- a/src/main/java/seedu/address/model/session/Interval.java
+++ b/src/main/java/seedu/address/model/session/Interval.java
@@ -30,7 +30,7 @@ public class Interval {
      */
     public Interval(LocalDateTime start, int duration) {
         requireNonNull(start);
-        checkArgument(isValidInterval(duration), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidInterval(duration), MESSAGE_DATE_TIME_CONSTRAINTS);
         this.start = start;
         this.durationInMinutes = duration;
     }

--- a/src/main/java/seedu/address/model/session/Session.java
+++ b/src/main/java/seedu/address/model/session/Session.java
@@ -35,6 +35,18 @@ public class Session implements CheckExisting<Session> {
     }
 
     /**
+     * Every field must be present and not null. To update a session's details
+     * after editing.
+     */
+    public Session(int id, Gym gym, ExerciseType exerciseType, Interval interval) {
+        requireAllNonNull(id, gym, exerciseType, interval);
+        this.id = id;
+        this.exerciseType = exerciseType;
+        this.interval = interval;
+        this.gym = gym;
+    }
+
+    /**
      * Creates a new Session object.
      * NOTE: DO NOT USE THIS FOR CLIENT INPUT; this is only for loading from database.
      */

--- a/src/test/java/seedu/address/logic/commands/client/ClientCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/client/ClientCommandTestUtil.java
@@ -22,6 +22,7 @@ import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.NameContainsSubstringPredicate;
 import seedu.address.testutil.EditClientDescriptorBuilder;
+import seedu.address.logic.commands.client.EditClientCommand.EditClientDescriptor;
 
 /**
  * Contains helper methods for testing commands.
@@ -59,8 +60,8 @@ public class ClientCommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditClientCommand.EditClientDescriptor DESC_AMY;
-    public static final EditClientCommand.EditClientDescriptor DESC_BOB;
+    public static final EditClientDescriptor DESC_AMY;
+    public static final EditClientDescriptor DESC_BOB;
 
     static {
         DESC_AMY = new EditClientDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/address/logic/commands/client/ClientCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/client/ClientCommandTestUtil.java
@@ -16,13 +16,13 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.client.EditClientCommand.EditClientDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.NameContainsSubstringPredicate;
 import seedu.address.testutil.EditClientDescriptorBuilder;
-import seedu.address.logic.commands.client.EditClientCommand.EditClientDescriptor;
 
 /**
  * Contains helper methods for testing commands.

--- a/src/test/java/seedu/address/logic/commands/client/ClientCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/client/ClientCommandTestUtil.java
@@ -127,5 +127,4 @@ public class ClientCommandTestUtil {
 
         assertEquals(1, model.getFilteredClientList().size());
     }
-
 }

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleCommandTest.java
@@ -2,36 +2,25 @@ package seedu.address.logic.commands.schedule;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_AMY;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_TAG_INJURY;
 import static seedu.address.logic.commands.client.ClientCommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.showClientAtIndex;
+import static seedu.address.logic.commands.schedule.RescheduleTestUtil.DESC_SCHA;
+import static seedu.address.logic.commands.schedule.RescheduleTestUtil.DESC_SCHB;
 import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SCHEDULE;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SCHEDULE;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
 
-import javax.management.Descriptor;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.client.EditClientCommand;
-import seedu.address.logic.commands.client.EditClientCommand.EditClientDescriptor;
-import seedu.address.model.AddressBook;
+import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.client.Client;
-import seedu.address.model.schedule.Schedule;
-import seedu.address.testutil.ClientBuilder;
-import seedu.address.testutil.EditClientDescriptorBuilder;
 import seedu.address.testutil.RescheduleDescriptorBuilder;
-import seedu.address.testutil.ScheduleBuilder;
-import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -130,35 +119,38 @@ public class RescheduleCommandTest {
     public void execute_invalidScheduleIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredScheduleList().size() + 1);
         RescheduleDescriptor descriptor = new RescheduleDescriptorBuilder().withSessionIndex(INDEX_FIRST_SCHEDULE).build();
-        RescheduleCommand rescheduleCommand = new RescheduleCommand(outOfBoundIndex, descriptor);
+        RescheduleCommand rescheduleCommand = new RescheduleCommand(outOfBoundIndex, INDEX_FIRST_SESSION, descriptor);
 
         assertCommandFailure(rescheduleCommand, model, Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
     }
 
-//    @Test
-//    public void equals() {
-//        final RescheduleCommand standardCommand = new RescheduleCommand(INDEX_FIRST_SCHEDULE,
-//                new RescheduleDescriptor());
-//
-//        // same values -> returns true
-//        RescheduleDescriptor copyDescriptor = new RescheduleDescriptor(DESC_AMY);
-//        RescheduleCommand commandWithSameValues = new RescheduleCommand(INDEX_FIRST_SCHEDULE, copyDescriptor);
-//        assertTrue(standardCommand.equals(commandWithSameValues));
-//
-//        // same object -> returns true
-//        assertTrue(standardCommand.equals(standardCommand));
-//
-//        // null -> returns false
-//        assertFalse(standardCommand.equals(null));
-//
-//        // different types -> returns false
-//        assertFalse(standardCommand.equals(new ClearCommand()));
-//
-//        // different index -> returns false
-//        assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_SECOND_SCHEDULE, DESC_AMY)));
-//
-//        // different descriptor -> returns false
-//        assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_FIRST_SCHEDULE, DESC_BOB)));
-//    }
+    @Test
+    public void equals() {
+        final RescheduleCommand standardCommand = new RescheduleCommand(INDEX_FIRST_SCHEDULE, INDEX_FIRST_SESSION,
+                DESC_SCHA);
+
+        // same values -> returns true
+        RescheduleDescriptor copyDescriptor = new RescheduleDescriptor(DESC_SCHA);
+        RescheduleCommand commandWithSameValues = new RescheduleCommand(INDEX_FIRST_SCHEDULE, INDEX_FIRST_SESSION,
+                copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_SECOND_SCHEDULE,
+                INDEX_SECOND_SESSION ,DESC_SCHA)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_FIRST_SCHEDULE,
+                INDEX_FIRST_SESSION, DESC_SCHB)));
+    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleCommandTest.java
@@ -36,7 +36,8 @@ public class RescheduleCommandTest {
     //        RescheduleDescriptor descriptor = new RescheduleDescriptorBuilder(editedSchedule).build();
     //        RescheduleCommand rescheduleCommand = new RescheduleCommand(INDEX_FIRST_SCHEDULE, descriptor);
     //
-    //        String expectedMessage = String.format(RescheduleCommand.MESSAGE_EDIT_SCHEDULE_SUCCESS, rescheduleCommand);
+    //        String expectedMessage = String.format(RescheduleCommand.MESSAGE_EDIT_SCHEDULE_SUCCESS
+    //        , rescheduleCommand);
     //
     //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
     //        expectedModel.setSchedule(model.getFilteredScheduleList().get(0), editedSchedule);
@@ -67,7 +68,8 @@ public class RescheduleCommandTest {
     //
     //    @Test
     //    public void execute_noFieldSpecifiedUnfilteredList_success() {
-    //        EditClientCommand editClientCommand = new EditClientCommand(INDEX_FIRST_CLIENT, new EditClientDescriptor());
+    //        EditClientCommand editClientCommand = new EditClientCommand(INDEX_FIRST_CLIENT,
+    //        new EditClientDescriptor());
     //        Client editedClient = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
     //
     //        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS, editedClient);
@@ -118,7 +120,8 @@ public class RescheduleCommandTest {
     @Test
     public void execute_invalidScheduleIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredScheduleList().size() + 1);
-        RescheduleDescriptor descriptor = new RescheduleDescriptorBuilder().withSessionIndex(INDEX_FIRST_SCHEDULE).build();
+        RescheduleDescriptor descriptor = new RescheduleDescriptorBuilder()
+                .withSessionIndex(INDEX_FIRST_SCHEDULE).build();
         RescheduleCommand rescheduleCommand = new RescheduleCommand(outOfBoundIndex, INDEX_FIRST_SESSION, descriptor);
 
         assertCommandFailure(rescheduleCommand, model, Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
@@ -146,7 +149,7 @@ public class RescheduleCommandTest {
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_SECOND_SCHEDULE,
-                INDEX_SECOND_SESSION ,DESC_SCHA)));
+                INDEX_SECOND_SESSION , DESC_SCHA)));
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_FIRST_SCHEDULE,

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleCommandTest.java
@@ -1,0 +1,164 @@
+package seedu.address.logic.commands.schedule;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_AMY;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_TAG_INJURY;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.showClientAtIndex;
+import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.*;
+
+import javax.management.Descriptor;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.client.EditClientCommand;
+import seedu.address.logic.commands.client.EditClientCommand.EditClientDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.client.Client;
+import seedu.address.model.schedule.Schedule;
+import seedu.address.testutil.ClientBuilder;
+import seedu.address.testutil.EditClientDescriptorBuilder;
+import seedu.address.testutil.RescheduleDescriptorBuilder;
+import seedu.address.testutil.ScheduleBuilder;
+import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
+ * EditClientCommand.
+ */
+public class RescheduleCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    //    @Test
+    //    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    //        Schedule editedSchedule = new ScheduleBuilder().build();
+    //        RescheduleDescriptor descriptor = new RescheduleDescriptorBuilder(editedSchedule).build();
+    //        RescheduleCommand rescheduleCommand = new RescheduleCommand(INDEX_FIRST_SCHEDULE, descriptor);
+    //
+    //        String expectedMessage = String.format(RescheduleCommand.MESSAGE_EDIT_SCHEDULE_SUCCESS, rescheduleCommand);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setSchedule(model.getFilteredScheduleList().get(0), editedSchedule);
+    //
+    //        assertCommandSuccess(rescheduleCommand, model, expectedMessage, expectedModel);
+    //    }
+    //
+    //    @Test
+    //    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+    //        Index indexLastClient = Index.fromOneBased(model.getFilteredClientList().size());
+    //        Client lastClient = model.getFilteredClientList().get(indexLastClient.getZeroBased());
+    //
+    //        ClientBuilder clientInList = new ClientBuilder(lastClient);
+    //        Client editedClient = clientInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+    //                .withTags(VALID_TAG_INJURY).build();
+    //
+    //        EditClientDescriptor descriptor = new EditClientDescriptorBuilder().withName(VALID_NAME_BOB)
+    //                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_INJURY).build();
+    //        EditClientCommand editClientCommand = new EditClientCommand(indexLastClient, descriptor);
+    //
+    //        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS, editedClient);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setClient(lastClient, editedClient);
+    //
+    //        assertCommandSuccess(editClientCommand, model, expectedMessage, expectedModel);
+    //    }
+    //
+    //    @Test
+    //    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    //        EditClientCommand editClientCommand = new EditClientCommand(INDEX_FIRST_CLIENT, new EditClientDescriptor());
+    //        Client editedClient = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
+    //
+    //        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS, editedClient);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //
+    //        assertCommandSuccess(editClientCommand, model, expectedMessage, expectedModel);
+    //    }
+    //
+    //    @Test
+    //    public void execute_filteredList_success() {
+    //        showClientAtIndex(model, INDEX_FIRST_CLIENT);
+    //
+    //        Client clientInFilteredList = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
+    //        Client editedClient = new ClientBuilder(clientInFilteredList).withName(VALID_NAME_BOB).build();
+    //        EditClientCommand editClientCommand = new EditClientCommand(INDEX_FIRST_CLIENT,
+    //                new EditClientDescriptorBuilder().withName(VALID_NAME_BOB).build());
+    //
+    //        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS, editedClient);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setClient(model.getFilteredClientList().get(0), editedClient);
+    //
+    //        assertCommandSuccess(editClientCommand, model, expectedMessage, expectedModel);
+    //    }
+    //
+    //    @Test
+    //    public void execute_duplicateClientUnfilteredList_failure() {
+    //        Client firstClient = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
+    //        EditClientDescriptor descriptor = new EditClientDescriptorBuilder(firstClient).build();
+    //        EditClientCommand editClientCommand = new EditClientCommand(INDEX_SECOND_CLIENT, descriptor);
+    //
+    //        assertCommandFailure(editClientCommand, model, EditClientCommand.MESSAGE_DUPLICATE_CLIENT);
+    //    }
+    //
+    //    @Test
+    //    public void execute_duplicateClientFilteredList_failure() {
+    //        showClientAtIndex(model, INDEX_FIRST_CLIENT);
+    //
+    //        // edit Client in filtered list into a duplicate in address book
+    //        Client clientInList = model.getAddressBook().getClientList().get(INDEX_SECOND_CLIENT.getZeroBased());
+    //        EditClientCommand editClientCommand = new EditClientCommand(INDEX_FIRST_CLIENT,
+    //                new EditClientDescriptorBuilder(clientInList).build());
+    //
+    //        assertCommandFailure(editClientCommand, model, EditClientCommand.MESSAGE_DUPLICATE_CLIENT);
+    //    }
+
+    @Test
+    public void execute_invalidScheduleIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredScheduleList().size() + 1);
+        RescheduleDescriptor descriptor = new RescheduleDescriptorBuilder().withSessionIndex(INDEX_FIRST_SCHEDULE).build();
+        RescheduleCommand rescheduleCommand = new RescheduleCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(rescheduleCommand, model, Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
+    }
+
+//    @Test
+//    public void equals() {
+//        final RescheduleCommand standardCommand = new RescheduleCommand(INDEX_FIRST_SCHEDULE,
+//                new RescheduleDescriptor());
+//
+//        // same values -> returns true
+//        RescheduleDescriptor copyDescriptor = new RescheduleDescriptor(DESC_AMY);
+//        RescheduleCommand commandWithSameValues = new RescheduleCommand(INDEX_FIRST_SCHEDULE, copyDescriptor);
+//        assertTrue(standardCommand.equals(commandWithSameValues));
+//
+//        // same object -> returns true
+//        assertTrue(standardCommand.equals(standardCommand));
+//
+//        // null -> returns false
+//        assertFalse(standardCommand.equals(null));
+//
+//        // different types -> returns false
+//        assertFalse(standardCommand.equals(new ClearCommand()));
+//
+//        // different index -> returns false
+//        assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_SECOND_SCHEDULE, DESC_AMY)));
+//
+//        // different descriptor -> returns false
+//        assertFalse(standardCommand.equals(new RescheduleCommand(INDEX_FIRST_SCHEDULE, DESC_BOB)));
+//    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleDescriptorTest.java
@@ -15,33 +15,33 @@ import seedu.address.testutil.RescheduleDescriptorBuilder;
 
 public class RescheduleDescriptorTest {
 
-        @Test
-        public void equals() {
-            // same values -> returns true
-            RescheduleDescriptor descriptorWithSameValues = new RescheduleDescriptor(DESC_SCHA);
-            assertTrue(DESC_SCHA.equals(descriptorWithSameValues));
+    @Test
+    public void equals() {
+        // same values -> returns true
+        RescheduleDescriptor descriptorWithSameValues = new RescheduleDescriptor(DESC_SCHA);
+        assertTrue(DESC_SCHA.equals(descriptorWithSameValues));
 
-            // same object -> returns true
-            assertTrue(DESC_SCHA.equals(DESC_SCHA));
+        // same object -> returns true
+        assertTrue(DESC_SCHA.equals(DESC_SCHA));
 
-            // null -> returns false
-            assertFalse(DESC_SCHA.equals(null));
+        // null -> returns false
+        assertFalse(DESC_SCHA.equals(null));
 
-            // different types -> returns false
-            assertFalse(DESC_SCHA.equals(5));
+        // different types -> returns false
+        assertFalse(DESC_SCHA.equals(5));
 
-            // different values -> returns false
-            assertFalse(DESC_SCHA.equals(DESC_SCHB));
+        // different values -> returns false
+        assertFalse(DESC_SCHA.equals(DESC_SCHB));
 
-            // different client index -> returns false
-            RescheduleDescriptor editedAmy = new RescheduleDescriptorBuilder(DESC_SCHA)
-                    .withClientIndex(Index.fromOneBased(Integer.parseInt(VALID_CLIENT_INDEX_SCHB))).build();
-            assertFalse(DESC_SCHA.equals(editedAmy));
+        // different client index -> returns false
+        RescheduleDescriptor editedAmy = new RescheduleDescriptorBuilder(DESC_SCHA)
+                .withClientIndex(Index.fromOneBased(Integer.parseInt(VALID_CLIENT_INDEX_SCHB))).build();
+        assertFalse(DESC_SCHA.equals(editedAmy));
 
-            // different session index -> returns false
-            editedAmy = new RescheduleDescriptorBuilder(DESC_SCHA)
-                    .withSessionIndex(Index.fromOneBased(Integer.parseInt(VALID_SESSION_INDEX_SCHB))).build();
-            assertFalse(DESC_SCHA.equals(editedAmy));
+        // different session index -> returns false
+        editedAmy = new RescheduleDescriptorBuilder(DESC_SCHA)
+                .withSessionIndex(Index.fromOneBased(Integer.parseInt(VALID_SESSION_INDEX_SCHB))).build();
+        assertFalse(DESC_SCHA.equals(editedAmy));
 
-        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleDescriptorTest.java
@@ -2,43 +2,46 @@ package seedu.address.logic.commands.schedule;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_AMY;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.schedule.RescheduleTestUtil.DESC_SCHA;
+import static seedu.address.logic.commands.schedule.RescheduleTestUtil.DESC_SCHB;
+import static seedu.address.logic.commands.schedule.RescheduleTestUtil.VALID_CLIENT_INDEX_SCHB;
+import static seedu.address.logic.commands.schedule.RescheduleTestUtil.VALID_SESSION_INDEX_SCHB;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
 import seedu.address.testutil.RescheduleDescriptorBuilder;
 
 public class RescheduleDescriptorTest {
 
-    //    @Test
-    //    public void equals() {
-    //        // same values -> returns true
-    //        RescheduleDescriptor descriptorWithSameValues = new RescheduleDescriptor(DESC_AMY);
-    //        assertTrue(DESC_AMY.equals(descriptorWithSameValues));
-    //
-    //        // same object -> returns true
-    //        assertTrue(DESC_AMY.equals(DESC_AMY));
-    //
-    //        // null -> returns false
-    //        assertFalse(DESC_AMY.equals(null));
-    //
-    //        // different types -> returns false
-    //        assertFalse(DESC_AMY.equals(5));
-    //
-    //        // different values -> returns false
-    //        assertFalse(DESC_AMY.equals(DESC_BOB));
-    //
-    //        // different client index -> returns false
-    //        RescheduleDescriptor editedAmy = new RescheduleDescriptorBuilder(DESC_AMY).withClientIndex(VALID_NAME_BOB).build();
-    //        assertFalse(DESC_AMY.equals(editedAmy));
-    //
-    //        // different session index -> returns false
-    //        editedAmy = new RescheduleDescriptorBuilder(DESC_AMY).withSessionIndex(VALID_PHONE_BOB).build();
-    //        assertFalse(DESC_AMY.equals(editedAmy));
-    //
-    //    }
+        @Test
+        public void equals() {
+            // same values -> returns true
+            RescheduleDescriptor descriptorWithSameValues = new RescheduleDescriptor(DESC_SCHA);
+            assertTrue(DESC_SCHA.equals(descriptorWithSameValues));
+
+            // same object -> returns true
+            assertTrue(DESC_SCHA.equals(DESC_SCHA));
+
+            // null -> returns false
+            assertFalse(DESC_SCHA.equals(null));
+
+            // different types -> returns false
+            assertFalse(DESC_SCHA.equals(5));
+
+            // different values -> returns false
+            assertFalse(DESC_SCHA.equals(DESC_SCHB));
+
+            // different client index -> returns false
+            RescheduleDescriptor editedAmy = new RescheduleDescriptorBuilder(DESC_SCHA)
+                    .withClientIndex(Index.fromOneBased(Integer.parseInt(VALID_CLIENT_INDEX_SCHB))).build();
+            assertFalse(DESC_SCHA.equals(editedAmy));
+
+            // different session index -> returns false
+            editedAmy = new RescheduleDescriptorBuilder(DESC_SCHA)
+                    .withSessionIndex(Index.fromOneBased(Integer.parseInt(VALID_SESSION_INDEX_SCHB))).build();
+            assertFalse(DESC_SCHA.equals(editedAmy));
+
+        }
 }

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleDescriptorTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands.schedule;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_AMY;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.client.ClientCommandTestUtil.VALID_PHONE_BOB;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
+import seedu.address.testutil.RescheduleDescriptorBuilder;
+
+public class RescheduleDescriptorTest {
+
+    //    @Test
+    //    public void equals() {
+    //        // same values -> returns true
+    //        RescheduleDescriptor descriptorWithSameValues = new RescheduleDescriptor(DESC_AMY);
+    //        assertTrue(DESC_AMY.equals(descriptorWithSameValues));
+    //
+    //        // same object -> returns true
+    //        assertTrue(DESC_AMY.equals(DESC_AMY));
+    //
+    //        // null -> returns false
+    //        assertFalse(DESC_AMY.equals(null));
+    //
+    //        // different types -> returns false
+    //        assertFalse(DESC_AMY.equals(5));
+    //
+    //        // different values -> returns false
+    //        assertFalse(DESC_AMY.equals(DESC_BOB));
+    //
+    //        // different client index -> returns false
+    //        RescheduleDescriptor editedAmy = new RescheduleDescriptorBuilder(DESC_AMY).withClientIndex(VALID_NAME_BOB).build();
+    //        assertFalse(DESC_AMY.equals(editedAmy));
+    //
+    //        // different session index -> returns false
+    //        editedAmy = new RescheduleDescriptorBuilder(DESC_AMY).withSessionIndex(VALID_PHONE_BOB).build();
+    //        assertFalse(DESC_AMY.equals(editedAmy));
+    //
+    //    }
+}

--- a/src/test/java/seedu/address/logic/commands/schedule/RescheduleTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/schedule/RescheduleTestUtil.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.commands.schedule;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
+import seedu.address.testutil.RescheduleDescriptorBuilder;
+
+/**
+ * Contains helper methods for testing commands.
+ */
+public class RescheduleTestUtil {
+
+    public static final String VALID_CLIENT_INDEX_SCHA = "1";
+    public static final String VALID_CLIENT_INDEX_SCHB = "2";
+    public static final String VALID_SESSION_INDEX_SCHA = "1";
+    public static final String VALID_SESSION_INDEX_SCHB = "2";
+
+    public static final RescheduleDescriptor DESC_SCHA;
+    public static final RescheduleDescriptor DESC_SCHB;
+
+    static {
+        DESC_SCHA = new RescheduleDescriptorBuilder()
+                .withClientIndex(Index.fromOneBased(Integer.parseInt(VALID_CLIENT_INDEX_SCHA)))
+                .withSessionIndex(Index.fromOneBased(Integer.parseInt(VALID_SESSION_INDEX_SCHA))).build();
+        DESC_SCHB = new RescheduleDescriptorBuilder()
+                .withClientIndex(Index.fromOneBased(Integer.parseInt(VALID_CLIENT_INDEX_SCHB)))
+                .withSessionIndex(Index.fromOneBased(Integer.parseInt(VALID_SESSION_INDEX_SCHB))).build();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -1,0 +1,171 @@
+package seedu.address.logic.commands.session;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
+import static seedu.address.testutil.TypicalSessions.getTypicalAddressBook;
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.session.Session;
+import seedu.address.testutil.SessionBuilder;
+import seedu.address.testutil.EditSessionDescriptorBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
+ * EditSessionCommand.
+ */
+public class EditSessionCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+//    @Test
+//    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+//        Session editedSession = new SessionBuilder().build();
+//        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(editedSession).build();
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, descriptor);
+//
+//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+//
+//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+//        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
+//
+//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+//    }
+
+//    @Test
+//    public void execute_someFieldsSpecifiedUnfilteredList_success() throws ParseException {
+//        Index indexLastSession = Index.fromOneBased(model.getFilteredSessionList().size());
+//        Session lastSession = model.getFilteredSessionList().get(indexLastSession.getZeroBased());
+//
+//        SessionBuilder SessionInList = new SessionBuilder(lastSession);
+//        Session editedSession = SessionInList.withGym(VALID_GYM_GETWELL).withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+//                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
+//
+//        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
+//                .withGym(VALID_GYM_GETWELL)
+//                .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+//                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(indexLastSession, descriptor);
+//
+//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+//
+//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+//        expectedModel.setSession(lastSession, editedSession);
+//
+//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+//    }
+
+//    @Test
+//    public void execute_noFieldSpecifiedUnfilteredList_success() {
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, new EditSessionDescriptor());
+//        Session editedSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+//
+//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+//
+//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+//
+//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+//    }
+
+//    @Test
+//    public void execute_filteredList_success() {
+//        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+//
+//        Session SessionInFilteredList = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+//        Session editedSession = new SessionBuilder(SessionInFilteredList).withGym(VALID_GYM_GETWELL).build();
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
+//                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
+//
+//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_DUPLICATE_SESSION, editedSession);
+//
+//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+//        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
+//
+//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+//    }
+
+//    @Test
+//    public void execute_duplicateSessionUnfilteredList_failure() {
+//        Session firstSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+//        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(firstSession).build();
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_SECOND_SESSION, descriptor);
+//
+//        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
+//    }
+
+//    @Test
+//    public void execute_duplicateSessionFilteredList_failure() {
+//        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+//
+//        // edit Session in filtered list into a duplicate in address book
+//        Session sessionInList = model.getAddressBook().getSessionList().get(INDEX_SECOND_SESSION.getZeroBased());
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
+//                new EditSessionDescriptorBuilder(sessionInList).build());
+//
+//        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
+//    }
+
+    @Test
+    public void execute_invalidSessionIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredSessionList().size() + 1);
+        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build();
+        EditSessionCommand editSessionCommand = new EditSessionCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+    }
+
+//    /**
+//     * Edit filtered list where index is larger than size of filtered list,
+//     * but smaller than size of address book
+//     */
+//    @Test
+//    public void execute_invalidSessionIndexFilteredList_failure() {
+//        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+//        Index outOfBoundIndex = INDEX_SECOND_SESSION;
+//        // ensures that outOfBoundIndex is still in bounds of address book list
+//        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getSessionList().size());
+//
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(outOfBoundIndex,
+//                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
+//
+//        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+//    }
+
+    @Test
+    public void equals() {
+        final EditSessionCommand standardCommand = new EditSessionCommand(INDEX_FIRST_SESSION, DESC_GETWELL);
+
+        // same values -> returns true
+        EditSessionDescriptor copyDescriptor = new EditSessionDescriptor(DESC_GETWELL);
+        EditSessionCommand commandWithSameValues = new EditSessionCommand(INDEX_FIRST_SESSION, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditSessionCommand(INDEX_SECOND_SESSION, DESC_GETWELL)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditSessionCommand(INDEX_FIRST_SESSION, DESC_MACHOMAN)));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -49,7 +49,8 @@ public class EditSessionCommandTest {
     //        Session lastSession = model.getFilteredSessionList().get(indexLastSession.getZeroBased());
     //
     //        SessionBuilder SessionInList = new SessionBuilder(lastSession);
-    //        Session editedSession = SessionInList.withGym(VALID_GYM_GETWELL).withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+    //        Session editedSession = SessionInList.withGym(VALID_GYM_GETWELL)
+    //        .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
     //                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
     //
     //        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -18,8 +18,8 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.testutil.EditSessionDescriptorBuilder;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -115,7 +115,7 @@ public class EditSessionCommandTest {
 //        new EditSessionDescriptorBuilder(sessionInList).build());
 //
 //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
-//    }
+//  }
 
     @Test
     public void execute_invalidSessionIndexUnfilteredList_failure() {
@@ -141,7 +141,7 @@ public class EditSessionCommandTest {
 //                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
 //
 //        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
-//    }
+//  }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -29,19 +29,19 @@ public class EditSessionCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    //    @Test
-    //    public void execute_allFieldsSpecifiedUnfilteredList_success() {
-    //        Session editedSession = new SessionBuilder().build();
-    //        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(editedSession).build();
-    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, descriptor);
+    //        @Test
+    //        public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    //            Session editedSession = new SessionBuilder().build();
+    //            EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(editedSession).build();
+    //            EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, descriptor);
     //
-    //        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+    //            String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
     //
-    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-    //        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
+    //            Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //            expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
     //
-    //        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
-    //    }
+    //            assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+    //        }
 
     //    @Test
     //    public void execute_someFieldsSpecifiedUnfilteredList_success() throws ParseException {
@@ -97,14 +97,14 @@ public class EditSessionCommandTest {
     //        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
     //    }
 
-    //    @Test
-    //    public void execute_duplicateSessionUnfilteredList_failure() {
-    //        Session firstSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
-    //        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(firstSession).build();
-    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_SECOND_SESSION, descriptor);
+    //        @Test
+    //        public void execute_duplicateSessionUnfilteredList_failure() {
+    //            Session firstSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+    //            EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(firstSession).build();
+    //            EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_SECOND_SESSION, descriptor);
     //
-    //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
-    //    }
+    //            assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
+    //        }
 
     //    @Test
     //    public void execute_duplicateSessionFilteredList_failure() {

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -115,7 +115,7 @@ public class EditSessionCommandTest {
 //        new EditSessionDescriptorBuilder(sessionInList).build());
 //
 //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
-//  }
+// }
 
     @Test
     public void execute_invalidSessionIndexUnfilteredList_failure() {
@@ -141,7 +141,7 @@ public class EditSessionCommandTest {
 //                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
 //
 //        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
-//  }
+// }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -2,25 +2,24 @@ package seedu.address.logic.commands.session;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
 import static seedu.address.testutil.TypicalSessions.getTypicalAddressBook;
-import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.session.Session;
-import seedu.address.testutil.SessionBuilder;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -69,7 +68,8 @@ public class EditSessionCommandTest {
 
 //    @Test
 //    public void execute_noFieldSpecifiedUnfilteredList_success() {
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, new EditSessionDescriptor());
+//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
+//        new EditSessionDescriptor());
 //        Session editedSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
 //
 //        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
@@ -109,10 +109,10 @@ public class EditSessionCommandTest {
 //    public void execute_duplicateSessionFilteredList_failure() {
 //        showSessionAtIndex(model, INDEX_FIRST_SESSION);
 //
-//        // edit Session in filtered list into a duplicate in address book
+//        edit Session in filtered list into a duplicate in address book
 //        Session sessionInList = model.getAddressBook().getSessionList().get(INDEX_SECOND_SESSION.getZeroBased());
 //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
-//                new EditSessionDescriptorBuilder(sessionInList).build());
+//        new EditSessionDescriptorBuilder(sessionInList).build());
 //
 //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
 //    }

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 /**
@@ -115,7 +115,7 @@ public class EditSessionCommandTest {
 //        new EditSessionDescriptorBuilder(sessionInList).build());
 //
 //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
-// }
+    //  }
 
     @Test
     public void execute_invalidSessionIndexUnfilteredList_failure() {
@@ -141,7 +141,7 @@ public class EditSessionCommandTest {
 //                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
 //
 //        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
-// }
+    // }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -29,92 +29,92 @@ public class EditSessionCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-//    @Test
-//    public void execute_allFieldsSpecifiedUnfilteredList_success() {
-//        Session editedSession = new SessionBuilder().build();
-//        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(editedSession).build();
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, descriptor);
-//
-//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
-//
-//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-//        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
-//
-//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
-//    }
+    //    @Test
+    //    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    //        Session editedSession = new SessionBuilder().build();
+    //        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(editedSession).build();
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, descriptor);
+    //
+    //        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
+    //
+    //        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+    //    }
 
-//    @Test
-//    public void execute_someFieldsSpecifiedUnfilteredList_success() throws ParseException {
-//        Index indexLastSession = Index.fromOneBased(model.getFilteredSessionList().size());
-//        Session lastSession = model.getFilteredSessionList().get(indexLastSession.getZeroBased());
-//
-//        SessionBuilder SessionInList = new SessionBuilder(lastSession);
-//        Session editedSession = SessionInList.withGym(VALID_GYM_GETWELL).withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-//                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
-//
-//        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
-//                .withGym(VALID_GYM_GETWELL)
-//                .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-//                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(indexLastSession, descriptor);
-//
-//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
-//
-//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-//        expectedModel.setSession(lastSession, editedSession);
-//
-//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
-//    }
+    //    @Test
+    //    public void execute_someFieldsSpecifiedUnfilteredList_success() throws ParseException {
+    //        Index indexLastSession = Index.fromOneBased(model.getFilteredSessionList().size());
+    //        Session lastSession = model.getFilteredSessionList().get(indexLastSession.getZeroBased());
+    //
+    //        SessionBuilder SessionInList = new SessionBuilder(lastSession);
+    //        Session editedSession = SessionInList.withGym(VALID_GYM_GETWELL).withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+    //                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
+    //
+    //        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
+    //                .withGym(VALID_GYM_GETWELL)
+    //                .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+    //                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(indexLastSession, descriptor);
+    //
+    //        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setSession(lastSession, editedSession);
+    //
+    //        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+    //    }
 
-//    @Test
-//    public void execute_noFieldSpecifiedUnfilteredList_success() {
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
-//        new EditSessionDescriptor());
-//        Session editedSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
-//
-//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
-//
-//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-//
-//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
-//    }
+    //    @Test
+    //    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
+    //        new EditSessionDescriptor());
+    //        Session editedSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+    //
+    //        String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //
+    //        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+    //    }
 
-//    @Test
-//    public void execute_filteredList_success() {
-//        showSessionAtIndex(model, INDEX_FIRST_SESSION);
-//
-//        Session SessionInFilteredList = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
-//        Session editedSession = new SessionBuilder(SessionInFilteredList).withGym(VALID_GYM_GETWELL).build();
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
-//                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
-//
-//        String expectedMessage = String.format(EditSessionCommand.MESSAGE_DUPLICATE_SESSION, editedSession);
-//
-//        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-//        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
-//
-//        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
-//    }
+    //    @Test
+    //    public void execute_filteredList_success() {
+    //        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+    //
+    //        Session SessionInFilteredList = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+    //        Session editedSession = new SessionBuilder(SessionInFilteredList).withGym(VALID_GYM_GETWELL).build();
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
+    //                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
+    //
+    //        String expectedMessage = String.format(EditSessionCommand.MESSAGE_DUPLICATE_SESSION, editedSession);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);
+    //
+    //        assertCommandSuccess(editSessionCommand, model, expectedMessage, expectedModel);
+    //    }
 
-//    @Test
-//    public void execute_duplicateSessionUnfilteredList_failure() {
-//        Session firstSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
-//        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(firstSession).build();
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_SECOND_SESSION, descriptor);
-//
-//        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
-//    }
+    //    @Test
+    //    public void execute_duplicateSessionUnfilteredList_failure() {
+    //        Session firstSession = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+    //        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(firstSession).build();
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_SECOND_SESSION, descriptor);
+    //
+    //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
+    //    }
 
-//    @Test
-//    public void execute_duplicateSessionFilteredList_failure() {
-//        showSessionAtIndex(model, INDEX_FIRST_SESSION);
-//
-//        edit Session in filtered list into a duplicate in address book
-//        Session sessionInList = model.getAddressBook().getSessionList().get(INDEX_SECOND_SESSION.getZeroBased());
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
-//        new EditSessionDescriptorBuilder(sessionInList).build());
-//
-//        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
+    //    @Test
+    //    public void execute_duplicateSessionFilteredList_failure() {
+    //        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+    //
+    //        edit Session in filtered list into a duplicate in address book
+    //        Session sessionInList = model.getAddressBook().getSessionList().get(INDEX_SECOND_SESSION.getZeroBased());
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION,
+    //        new EditSessionDescriptorBuilder(sessionInList).build());
+    //
+    //        assertCommandFailure(editSessionCommand, model, EditSessionCommand.MESSAGE_DUPLICATE_SESSION);
     //  }
 
     @Test
@@ -126,21 +126,21 @@ public class EditSessionCommandTest {
         assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
     }
 
-//    /**
-//     * Edit filtered list where index is larger than size of filtered list,
-//     * but smaller than size of address book
-//     */
-//    @Test
-//    public void execute_invalidSessionIndexFilteredList_failure() {
-//        showSessionAtIndex(model, INDEX_FIRST_SESSION);
-//        Index outOfBoundIndex = INDEX_SECOND_SESSION;
-//        // ensures that outOfBoundIndex is still in bounds of address book list
-//        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getSessionList().size());
-//
-//        EditSessionCommand editSessionCommand = new EditSessionCommand(outOfBoundIndex,
-//                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
-//
-//        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+    //    /**
+    //     * Edit filtered list where index is larger than size of filtered list,
+    //     * but smaller than size of address book
+    //     */
+    //    @Test
+    //    public void execute_invalidSessionIndexFilteredList_failure() {
+    //        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+    //        Index outOfBoundIndex = INDEX_SECOND_SESSION;
+    //        // ensures that outOfBoundIndex is still in bounds of address book list
+    //        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getSessionList().size());
+    //
+    //        EditSessionCommand editSessionCommand = new EditSessionCommand(outOfBoundIndex,
+    //                new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build());
+    //
+    //        assertCommandFailure(editSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
     // }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionCommandTest.java
@@ -35,7 +35,8 @@ public class EditSessionCommandTest {
     //            EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder(editedSession).build();
     //            EditSessionCommand editSessionCommand = new EditSessionCommand(INDEX_FIRST_SESSION, descriptor);
     //
-    //            String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS, editedSession);
+    //            String expectedMessage = String.format(EditSessionCommand.MESSAGE_EDIT_SESSION_SUCCESS
+    //            , editedSession);
     //
     //            Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
     //            expectedModel.setSession(model.getFilteredSessionList().get(0), editedSession);

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands.session;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.testutil.EditSessionDescriptorBuilder;
+
+public class EditSessionDescriptorTest {
+
+    @Test
+    public void equals() throws ParseException {
+        // same values -> returns true
+        EditSessionDescriptor descriptorWithSameValues = new EditSessionDescriptor(DESC_GETWELL);
+        assertTrue(DESC_GETWELL.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_GETWELL.equals(DESC_GETWELL));
+
+        // null -> returns false
+        assertFalse(DESC_GETWELL.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_GETWELL.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_GETWELL.equals(DESC_MACHOMAN));
+
+        // different gym -> returns false
+        EditSessionDescriptor editedGetwell = new EditSessionDescriptorBuilder(DESC_GETWELL)
+                .withGym(VALID_GYM_MACHOMAN).build();
+        assertFalse(DESC_GETWELL.equals(editedGetwell));
+
+        // different exercise type -> returns false
+        editedGetwell = new EditSessionDescriptorBuilder(DESC_GETWELL)
+                .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN).build();
+        assertFalse(DESC_GETWELL.equals(editedGetwell));
+
+        // different interval -> returns false
+        editedGetwell = new EditSessionDescriptorBuilder(DESC_GETWELL)
+                .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN).build();
+        assertFalse(DESC_GETWELL.equals(editedGetwell));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
@@ -9,10 +9,12 @@ import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_
 import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
 import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.session.Interval;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 public class EditSessionDescriptorTest {
@@ -47,7 +49,8 @@ public class EditSessionDescriptorTest {
 
         // different interval -> returns false
         editedGetwell = new EditSessionDescriptorBuilder(DESC_GETWELL)
-                .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN).build();
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
+                        , Integer.parseInt(VALID_DURATION_MACHOMAN)).build();
         assertFalse(DESC_GETWELL.equals(editedGetwell));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_
 import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 
 import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
@@ -49,8 +50,8 @@ public class EditSessionDescriptorTest {
 
         // different interval -> returns false
         editedGetwell = new EditSessionDescriptorBuilder(DESC_GETWELL)
-                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
-                        , Integer.parseInt(VALID_DURATION_MACHOMAN)).build();
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER),
+                        Integer.parseInt(VALID_DURATION_MACHOMAN)).build();
         assertFalse(DESC_GETWELL.equals(editedGetwell));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
@@ -14,14 +14,13 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.session.Interval;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 public class EditSessionDescriptorTest {
 
     @Test
-    public void equals() throws ParseException {
+    public void equals() {
         // same values -> returns true
         EditSessionDescriptor descriptorWithSameValues = new EditSessionDescriptor(DESC_GETWELL);
         assertTrue(DESC_GETWELL.equals(descriptorWithSameValues));

--- a/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/EditSessionDescriptorTest.java
@@ -2,7 +2,12 @@ package seedu.address.logic.commands.session;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -7,6 +7,10 @@ import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.testutil.Assert.assertThrows;
 
+
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -16,9 +20,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.session.Session;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Contains helper methods for testing commands.

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -15,7 +15,6 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
-import seedu.address.logic.parser.session.SessionParserUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.session.Interval;
@@ -31,12 +30,10 @@ public class SessionCommandTestUtil {
     public static final String VALID_GYM_MACHOMAN = "Machoman gym";
     public static final String VALID_EXERCISE_TYPE_GETWELL = "Endurance";
     public static final String VALID_EXERCISE_TYPE_MACHOMAN = "Bodybuilder";
-    public static final LocalDateTime VALID_START_TIME_GETWELL =
-            LocalDateTime.parse("29/09/2020 1300", Interval.DATE_TIME_FORMATTER);
-    public static final LocalDateTime VALID_START_TIME_MACHOMAN =
-            LocalDateTime.parse("29/09/2020 1600", Interval.DATE_TIME_FORMATTER);
-    public static final int VALID_DURATION_GETWELL = 120;
-    public static final int VALID_DURATION_MACHOMAN = 150;
+    public static final String VALID_START_TIME_GETWELL = "29/09/2020 1300";
+    public static final String VALID_START_TIME_MACHOMAN = "29/09/2020 1600";
+    public static final String VALID_DURATION_GETWELL = "120";
+    public static final String VALID_DURATION_MACHOMAN = "150";
 
     public static final String GYM_DESC_GETWELL = " " + PREFIX_GYM + VALID_GYM_GETWELL;
     public static final String GYM_DESC_MACHOMAN = " " + PREFIX_GYM + VALID_GYM_MACHOMAN;
@@ -60,13 +57,15 @@ public class SessionCommandTestUtil {
     public static final EditSessionDescriptor DESC_GETWELL = new EditSessionDescriptorBuilder()
             .withGym(VALID_GYM_GETWELL)
             .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-            .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
-            .build();;
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER)
+                    , Integer.parseInt(VALID_DURATION_GETWELL))
+            .build();
     public static final EditSessionDescriptor DESC_MACHOMAN = new EditSessionDescriptorBuilder()
             .withGym(VALID_GYM_MACHOMAN)
             .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-            .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
-            .build();;
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
+                    , Integer.parseInt(VALID_DURATION_MACHOMAN))
+            .build();
 
     /**
      * Executes the given {@code command}, confirms that <br>

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -1,5 +1,12 @@
 package seedu.address.logic.commands.session;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
+import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.testutil.Assert.assertThrows;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -12,13 +19,6 @@ import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
-import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
-import static seedu.address.testutil.Assert.assertThrows;
 
 /**
  * Contains helper methods for testing commands.
@@ -123,7 +123,7 @@ public class SessionCommandTestUtil {
 //    /**
 //     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
 //     * {@code model}'s address book.
-//     */
+//    */
 //    public static void showSessionAtIndex(Model model, Index targetIndex) {
 //        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
 //

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -57,14 +57,14 @@ public class SessionCommandTestUtil {
     public static final EditSessionDescriptor DESC_GETWELL = new EditSessionDescriptorBuilder()
             .withGym(VALID_GYM_GETWELL)
             .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-            .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER)
-                    , Integer.parseInt(VALID_DURATION_GETWELL))
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER),
+                    Integer.parseInt(VALID_DURATION_GETWELL))
             .build();
     public static final EditSessionDescriptor DESC_MACHOMAN = new EditSessionDescriptorBuilder()
             .withGym(VALID_GYM_MACHOMAN)
             .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-            .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
-                    , Integer.parseInt(VALID_DURATION_MACHOMAN))
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER),
+                    Integer.parseInt(VALID_DURATION_MACHOMAN))
             .build();
 
     /**
@@ -110,17 +110,17 @@ public class SessionCommandTestUtil {
         assertEquals(expectedFilteredList, actualModel.getFilteredSessionList());
     }
 
-//    /**
-//     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
-//     * {@code model}'s address book.
-//    */
-//    public static void showSessionAtIndex(Model model, Index targetIndex) {
-//        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
-//
-//        Session session = model.getFilteredSessionList().get(targetIndex.getZeroBased());
-//        final String[] splitName = session.getName().fullName.split("\\s+");
-//        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
-//
-//        assertEquals(1, model.getFilteredSessionList().size());
+    //    /**
+    //     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
+    //     * {@code model}'s address book.
+    //    */
+    //    public static void showSessionAtIndex(Model model, Index targetIndex) {
+    //        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
+    //
+    //        Session session = model.getFilteredSessionList().get(targetIndex.getZeroBased());
+    //        final String[] splitName = session.getName().fullName.split("\\s+");
+    //        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
+    //
+    //        assertEquals(1, model.getFilteredSessionList().size());
     //  }
 }

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,9 +15,10 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.session.SessionParserUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.session.Interval;
 import seedu.address.model.session.Session;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
@@ -29,8 +31,10 @@ public class SessionCommandTestUtil {
     public static final String VALID_GYM_MACHOMAN = "Machoman gym";
     public static final String VALID_EXERCISE_TYPE_GETWELL = "Endurance";
     public static final String VALID_EXERCISE_TYPE_MACHOMAN = "Bodybuilder";
-    public static final String VALID_START_TIME_GETWELL = "29/09/2020 1300";
-    public static final String VALID_START_TIME_MACHOMAN = "29/09/2020 1600";
+    public static final LocalDateTime VALID_START_TIME_GETWELL =
+            LocalDateTime.parse("29/09/2020 1300", Interval.DATE_TIME_FORMATTER);
+    public static final LocalDateTime VALID_START_TIME_MACHOMAN =
+            LocalDateTime.parse("29/09/2020 1600", Interval.DATE_TIME_FORMATTER);
     public static final int VALID_DURATION_GETWELL = 120;
     public static final int VALID_DURATION_MACHOMAN = 150;
 
@@ -53,29 +57,16 @@ public class SessionCommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static EditSessionDescriptor DESC_GETWELL;
-    public static EditSessionDescriptor DESC_MACHOMAN;
-
-    static {
-        try {
-            DESC_GETWELL = new EditSessionDescriptorBuilder()
-                    .withGym(VALID_GYM_GETWELL)
-                    .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-                    .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
-                    .build();
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        try {
-            DESC_MACHOMAN = new EditSessionDescriptorBuilder()
-                    .withGym(VALID_GYM_MACHOMAN)
-                    .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-                    .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
-                    .build();
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-    }
+    public static final EditSessionDescriptor DESC_GETWELL = new EditSessionDescriptorBuilder()
+            .withGym(VALID_GYM_GETWELL)
+            .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+            .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
+            .build();;
+    public static final EditSessionDescriptor DESC_MACHOMAN = new EditSessionDescriptorBuilder()
+            .withGym(VALID_GYM_MACHOMAN)
+            .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
+            .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+            .build();;
 
     /**
      * Executes the given {@code command}, confirms that <br>
@@ -132,5 +123,5 @@ public class SessionCommandTestUtil {
 //        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
 //
 //        assertEquals(1, model.getFilteredSessionList().size());
-//  }
+    //  }
 }

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.testutil.Assert.assertThrows;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -133,5 +132,5 @@ public class SessionCommandTestUtil {
 //        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
 //
 //        assertEquals(1, model.getFilteredSessionList().size());
-//    }
+//  }
 }

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -1,21 +1,24 @@
 package seedu.address.logic.commands.session;
 
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.session.Session;
+import seedu.address.testutil.EditSessionDescriptorBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.testutil.Assert.assertThrows;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.session.Session;
 
 /**
  * Contains helper methods for testing commands.
@@ -28,8 +31,8 @@ public class SessionCommandTestUtil {
     public static final String VALID_EXERCISE_TYPE_MACHOMAN = "Bodybuilder";
     public static final String VALID_START_TIME_GETWELL = "29/09/2020 1300";
     public static final String VALID_START_TIME_MACHOMAN = "29/09/2020 1600";
-    public static final String VALID_DURATION_GETWELL = "120";
-    public static final String VALID_DURATION_MACHOMAN = "150";
+    public static final int VALID_DURATION_GETWELL = 120;
+    public static final int VALID_DURATION_MACHOMAN = 150;
 
     public static final String GYM_DESC_GETWELL = " " + PREFIX_GYM + VALID_GYM_GETWELL;
     public static final String GYM_DESC_MACHOMAN = " " + PREFIX_GYM + VALID_GYM_MACHOMAN;
@@ -45,28 +48,34 @@ public class SessionCommandTestUtil {
             " " + PREFIX_EXERCISE_TYPE; // empty string not allowed for gyms
     public static final String INVALID_START_TIME_DESC =
             " " + PREFIX_START_TIME + "29/09/2020"; // unsupported date time format
-    public static final String INVALID_DURATION_DESC = " " + PREFIX_DURATION + "123a"; // a not allowed in duration
+    public static final String INVALID_DURATION_DESC = " " + PREFIX_DURATION + "-123"; // a not allowed in duration
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    //    public static final EditSessionCommand.EditSessionDescriptor DESC_GETWELL;
-    //    public static final EditSessionCommand.EditSessionDescriptor DESC_MACHOMAN;
-    //
-    //    static {
-    //        DESC_GETWELL = new EditSessionDescriptorBuilder()
-    //                .withGYM(VALID_GYM_GETWELL)
-    //                .withEXERCISE_TYPE(VALID_EXERCISE_TYPE_GETWELL)
-    //                .withSTART_TIME(VALID_START_TIME_GETWELL)
-    //                .withDURATION(VALID_DURATION_GETWELL)
-    //                .withTags(VALID_TAG_ALLERGY).build();
-    //        DESC_MACHOMAN = new EditSessionDescriptorBuilder()
-    //                .withGYM(VALID_GYM_MACHOMAN)
-    //                .withEXERCISE_TYPE(VALID_EXERCISE_TYPE_MACHOMAN)
-    //                .withSTART_TIME(VALID_START_TIME_MACHOMAN)
-    //                .withDURATION(VALID_DURATION_MACHOMAN)
-    //                .withTags(VALID_TAG_INJURY, VALID_TAG_ALLERGY).build();
-    //    }
+    public static EditSessionDescriptor DESC_GETWELL;
+    public static EditSessionDescriptor DESC_MACHOMAN;
+
+    static {
+        try {
+            DESC_GETWELL = new EditSessionDescriptorBuilder()
+                    .withGym(VALID_GYM_GETWELL)
+                    .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+                    .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
+                    .build();
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        try {
+            DESC_MACHOMAN = new EditSessionDescriptorBuilder()
+                    .withGym(VALID_GYM_MACHOMAN)
+                    .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
+                    .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+                    .build();
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
 
     /**
      * Executes the given {@code command}, confirms that <br>
@@ -111,18 +120,17 @@ public class SessionCommandTestUtil {
         assertEquals(expectedFilteredList, actualModel.getFilteredSessionList());
     }
 
-    //    /*
-    //     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
-    //     * {@code model}'s address book.
-    //     */
-    //    public static void showSessionAtIndex(Model model, Index targetIndex) {
-    //        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
-    //
-    //        Session session = model.getFilteredSessionList().get(targetIndex.getZeroBased());
-    //        final String[] splitName = session.getName().fullName.split("\\s+");
-    //        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
-    //
-    //        assertEquals(1, model.getFilteredSessionList().size());
-    //    }
-
+//    /**
+//     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
+//     * {@code model}'s address book.
+//     */
+//    public static void showSessionAtIndex(Model model, Index targetIndex) {
+//        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
+//
+//        Session session = model.getFilteredSessionList().get(targetIndex.getZeroBased());
+//        final String[] splitName = session.getName().fullName.split("\\s+");
+//        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
+//
+//        assertEquals(1, model.getFilteredSessionList().size());
+//    }
 }

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -89,7 +89,7 @@ public class EditSessionCommandParserTest {
 //      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
 //      ExerciseType.MESSAGE_CONSTRAINTS);
 
-//              multiple invalid values, but only the first invalid value is captured
+        //      multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1"
                         + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
                         + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -2,7 +2,24 @@ package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
@@ -69,7 +86,8 @@ public class EditSessionCommandParserTest {
         //      assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
         //      Gym.MESSAGE_CONSTRAINTS);
         //
-        //      // valid gym followed by invalid exercise type. The test case for invalid gym followed by valid exercise type
+        //      // valid gym followed by invalid exercise type. The test case for invalid gym followed
+        //      by valid exercise type
         //      // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         //      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
         //      ExerciseType.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -1,0 +1,189 @@
+package seedu.address.logic.parser.session;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.session.EditSessionCommand;
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Gym;
+import seedu.address.model.session.Interval;
+import seedu.address.testutil.EditSessionDescriptorBuilder;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_DURATION_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.*;
+
+public class EditSessionCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditSessionCommand.MESSAGE_USAGE);
+
+    private final EditSessionCommandParser parser = new EditSessionCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_GYM_GETWELL, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + VALID_GYM_GETWELL, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + VALID_GYM_GETWELL, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_GYM_DESC, Gym.MESSAGE_CONSTRAINTS); // invalid gym
+        assertParseFailure(parser,
+                "1" + INVALID_EXERCISE_TYPE_DESC,
+                ExerciseType.MESSAGE_CONSTRAINTS); // invalid exercise type
+//        assertParseFailure(parser,
+//                "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC
+//                , Interval.MESSAGE_CONSTRAINTS); // invalid interval
+//
+//        // invalid gym followed by valid exercise type
+//        assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
+//                Gym.MESSAGE_CONSTRAINTS);
+//
+//        // valid gym followed by invalid exercise type. The test case for invalid gym followed by valid exercise type
+//        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
+//        assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
+//                ExerciseType.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
+                        + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,
+                Gym.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() throws ParseException {
+        Index targetIndex = INDEX_SECOND_SESSION;
+        String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL + EXERCISE_TYPE_DESC_GETWELL
+                + START_TIME_DESC_GETWELL + DURATION_DESC_GETWELL;
+
+        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
+                .withGym(VALID_GYM_GETWELL)
+                .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
+                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
+                .build();
+        EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_SESSION;
+        String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL + EXERCISE_TYPE_DESC_GETWELL;
+
+        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
+                .withGym(VALID_GYM_GETWELL)
+                .withExerciseType(VALID_EXERCISE_TYPE_GETWELL).build();
+        EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() throws ParseException {
+        // gym
+        Index targetIndex = INDEX_THIRD_SESSION;
+        String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL;
+        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder().withGym(VALID_GYM_GETWELL).build();
+        EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // exercise type
+        userInput = targetIndex.getOneBased() + EXERCISE_TYPE_DESC_GETWELL;
+        descriptor = new EditSessionDescriptorBuilder().withExerciseType(VALID_EXERCISE_TYPE_GETWELL).build();
+        expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // interval
+        userInput = targetIndex.getOneBased() + START_TIME_DESC_GETWELL + DURATION_DESC_GETWELL;
+        descriptor = new EditSessionDescriptorBuilder()
+                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
+        expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() throws ParseException {
+        Index targetIndex = INDEX_FIRST_SESSION;
+        String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL + EXERCISE_TYPE_DESC_GETWELL
+                + START_TIME_DESC_GETWELL + DURATION_DESC_GETWELL + GYM_DESC_MACHOMAN
+                + EXERCISE_TYPE_DESC_MACHOMAN + START_TIME_DESC_MACHOMAN + DURATION_DESC_MACHOMAN;
+
+        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
+                .withGym(VALID_GYM_MACHOMAN)
+                .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
+                .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+                .build();
+        EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() throws ParseException {
+        // no other valid values specified
+        Index targetIndex = INDEX_FIRST_SESSION;
+        String userInput = targetIndex.getOneBased() + INVALID_GYM_DESC + GYM_DESC_MACHOMAN;
+        EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder().withGym(VALID_GYM_MACHOMAN).build();
+        EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // other valid values specified
+        userInput = targetIndex.getOneBased() + GYM_DESC_MACHOMAN + EXERCISE_TYPE_DESC_MACHOMAN
+                + START_TIME_DESC_MACHOMAN
+                + DURATION_DESC_MACHOMAN;
+        descriptor = new EditSessionDescriptorBuilder()
+                .withGym(VALID_GYM_MACHOMAN)
+                .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
+                .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+                .build();
+        expectedCommand = new EditSessionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -2,24 +2,7 @@ package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
@@ -27,12 +10,12 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_SESSION;
 
 import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
 import seedu.address.model.session.Interval;
@@ -78,18 +61,18 @@ public class EditSessionCommandParserTest {
         assertParseFailure(parser,
                 "1" + INVALID_EXERCISE_TYPE_DESC,
                 ExerciseType.MESSAGE_CONSTRAINTS); // invalid exercise type
-//      assertParseFailure(parser,
-//      "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC
-//      , Interval.MESSAGE_CONSTRAINTS); // invalid interval
-//
-//      // invalid gym followed by valid exercise type
-//      assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
-//      Gym.MESSAGE_CONSTRAINTS);
-//
-//      // valid gym followed by invalid exercise type. The test case for invalid gym followed by valid exercise type
-//      // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-//      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
-//      ExerciseType.MESSAGE_CONSTRAINTS);
+        //      assertParseFailure(parser,
+        //      "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC
+        //      , Interval.MESSAGE_CONSTRAINTS); // invalid interval
+        //
+        //      // invalid gym followed by valid exercise type
+        //      assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
+        //      Gym.MESSAGE_CONSTRAINTS);
+        //
+        //      // valid gym followed by invalid exercise type. The test case for invalid gym followed by valid exercise type
+        //      // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
+        //      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
+        //      ExerciseType.MESSAGE_CONSTRAINTS);
 
         //      multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1"
@@ -107,8 +90,8 @@ public class EditSessionCommandParserTest {
         EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
                 .withGym(VALID_GYM_GETWELL)
                 .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-                .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER)
-                        , Integer.parseInt(VALID_DURATION_GETWELL))
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER),
+                        Integer.parseInt(VALID_DURATION_GETWELL))
                 .build();
         EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
 
@@ -163,8 +146,8 @@ public class EditSessionCommandParserTest {
         EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
                 .withGym(VALID_GYM_MACHOMAN)
                 .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
-                        , Integer.parseInt(VALID_DURATION_MACHOMAN))
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER),
+                        Integer.parseInt(VALID_DURATION_MACHOMAN))
                 .build();
         EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
 
@@ -187,8 +170,8 @@ public class EditSessionCommandParserTest {
         descriptor = new EditSessionDescriptorBuilder()
                 .withGym(VALID_GYM_MACHOMAN)
                 .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
-                        , Integer.parseInt(VALID_DURATION_MACHOMAN))
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER),
+                        Integer.parseInt(VALID_DURATION_MACHOMAN))
                 .build();
         expectedCommand = new EditSessionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -76,22 +76,17 @@ public class EditSessionCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_GYM_DESC, Gym.MESSAGE_CONSTRAINTS); // invalid gym
+        // invalid gym
+        assertParseFailure(parser, "1" + INVALID_GYM_DESC, Gym.MESSAGE_CONSTRAINTS);
+
+        // invalid exercise type
         assertParseFailure(parser,
                 "1" + INVALID_EXERCISE_TYPE_DESC,
-                ExerciseType.MESSAGE_CONSTRAINTS); // invalid exercise type
-        assertParseFailure(parser,
-          "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC,
-                Interval.MESSAGE_DATE_TIME_CONSTRAINTS); // invalid interval
-
-        // invalid gym followed
-        assertParseFailure(parser, "1" + INVALID_GYM_DESC,
-                Gym.MESSAGE_CONSTRAINTS);
-
-        // invalid exercise type. The test case for invalid gym followed by valid exercise type
-        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, "1" + INVALID_EXERCISE_TYPE_DESC,
                 ExerciseType.MESSAGE_CONSTRAINTS);
+
+        // invalid interval
+        assertParseFailure(parser, "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC,
+                Interval.MESSAGE_DATE_TIME_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1"

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -2,7 +2,24 @@ package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
@@ -15,8 +32,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
+import seedu.address.model.session.ExerciseType;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 public class EditSessionCommandParserTest {
@@ -73,9 +90,10 @@ public class EditSessionCommandParserTest {
 //      ExerciseType.MESSAGE_CONSTRAINTS);
 
 //      multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
+        assertParseFailure(parser, "1"
+                        + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
                         + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,
-                Gym.MESSAGE_CONSTRAINTS);
+                        Gym.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -2,7 +2,26 @@ package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_DURATION_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
@@ -69,13 +88,12 @@ public class EditSessionCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_GYM_DESC,
                 Gym.MESSAGE_CONSTRAINTS);
 
-        // invalid exercise type. The test case for invalid gym followed
-        // by valid exercise type
+        // invalid exercise type. The test case for invalid gym followed by valid exercise type
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + INVALID_EXERCISE_TYPE_DESC,
                 ExerciseType.MESSAGE_CONSTRAINTS);
 
-        //multiple invalid values, but only the first invalid value is captured
+        // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1"
                         + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
                         + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -32,8 +32,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.session.Gym;
 import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Gym;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 public class EditSessionCommandParserTest {
@@ -89,7 +89,7 @@ public class EditSessionCommandParserTest {
 //      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
 //      ExerciseType.MESSAGE_CONSTRAINTS);
 
-//      multiple invalid values, but only the first invalid value is captured
+//              multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1"
                         + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
                         + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -1,40 +1,23 @@
 package seedu.address.logic.parser.session;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_SESSION;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
-import seedu.address.model.session.Interval;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_DURATION_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_START_TIME_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.*;
 
 public class EditSessionCommandParserTest {
 
@@ -76,20 +59,20 @@ public class EditSessionCommandParserTest {
         assertParseFailure(parser,
                 "1" + INVALID_EXERCISE_TYPE_DESC,
                 ExerciseType.MESSAGE_CONSTRAINTS); // invalid exercise type
-//        assertParseFailure(parser,
-//                "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC
-//                , Interval.MESSAGE_CONSTRAINTS); // invalid interval
+//      assertParseFailure(parser,
+//      "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC
+//      , Interval.MESSAGE_CONSTRAINTS); // invalid interval
 //
-//        // invalid gym followed by valid exercise type
-//        assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
-//                Gym.MESSAGE_CONSTRAINTS);
+//      // invalid gym followed by valid exercise type
+//      assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
+//      Gym.MESSAGE_CONSTRAINTS);
 //
-//        // valid gym followed by invalid exercise type. The test case for invalid gym followed by valid exercise type
-//        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-//        assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
-//                ExerciseType.MESSAGE_CONSTRAINTS);
+//      // valid gym followed by invalid exercise type. The test case for invalid gym followed by valid exercise type
+//      // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
+//      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
+//      ExerciseType.MESSAGE_CONSTRAINTS);
 
-        // multiple invalid values, but only the first invalid value is captured
+//      multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
                         + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,
                 Gym.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -26,6 +26,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_SESSION;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -34,6 +35,7 @@ import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescri
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
+import seedu.address.model.session.Interval;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
 public class EditSessionCommandParserTest {
@@ -97,7 +99,7 @@ public class EditSessionCommandParserTest {
     }
 
     @Test
-    public void parse_allFieldsSpecified_success() throws ParseException {
+    public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_SESSION;
         String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL + EXERCISE_TYPE_DESC_GETWELL
                 + START_TIME_DESC_GETWELL + DURATION_DESC_GETWELL;
@@ -105,7 +107,8 @@ public class EditSessionCommandParserTest {
         EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
                 .withGym(VALID_GYM_GETWELL)
                 .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER)
+                        , Integer.parseInt(VALID_DURATION_GETWELL))
                 .build();
         EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
 
@@ -126,7 +129,7 @@ public class EditSessionCommandParserTest {
     }
 
     @Test
-    public void parse_oneFieldSpecified_success() throws ParseException {
+    public void parse_oneFieldSpecified_success() {
         // gym
         Index targetIndex = INDEX_THIRD_SESSION;
         String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL;
@@ -143,14 +146,15 @@ public class EditSessionCommandParserTest {
         // interval
         userInput = targetIndex.getOneBased() + START_TIME_DESC_GETWELL + DURATION_DESC_GETWELL;
         descriptor = new EditSessionDescriptorBuilder()
-                .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL).build();
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER),
+                        Integer.parseInt(VALID_DURATION_GETWELL)).build();
         expectedCommand = new EditSessionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
     }
 
     @Test
-    public void parse_multipleRepeatedFields_acceptsLast() throws ParseException {
+    public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_SESSION;
         String userInput = targetIndex.getOneBased() + GYM_DESC_GETWELL + EXERCISE_TYPE_DESC_GETWELL
                 + START_TIME_DESC_GETWELL + DURATION_DESC_GETWELL + GYM_DESC_MACHOMAN
@@ -159,7 +163,8 @@ public class EditSessionCommandParserTest {
         EditSessionDescriptor descriptor = new EditSessionDescriptorBuilder()
                 .withGym(VALID_GYM_MACHOMAN)
                 .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-                .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
+                        , Integer.parseInt(VALID_DURATION_MACHOMAN))
                 .build();
         EditSessionCommand expectedCommand = new EditSessionCommand(targetIndex, descriptor);
 
@@ -167,7 +172,7 @@ public class EditSessionCommandParserTest {
     }
 
     @Test
-    public void parse_invalidValueFollowedByValidValue_success() throws ParseException {
+    public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_SESSION;
         String userInput = targetIndex.getOneBased() + INVALID_GYM_DESC + GYM_DESC_MACHOMAN;
@@ -182,7 +187,8 @@ public class EditSessionCommandParserTest {
         descriptor = new EditSessionDescriptorBuilder()
                 .withGym(VALID_GYM_MACHOMAN)
                 .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-                .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+                .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
+                        , Integer.parseInt(VALID_DURATION_MACHOMAN))
                 .build();
         expectedCommand = new EditSessionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/EditSessionCommandParserTest.java
@@ -2,24 +2,7 @@ package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.session.EditSessionCommand.MESSAGE_NOT_EDITED;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.DURATION_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.EXERCISE_TYPE_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.GYM_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_EXERCISE_TYPE_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.INVALID_GYM_DESC;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.START_TIME_DESC_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_DURATION_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_EXERCISE_TYPE_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_GYM_MACHOMAN;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
-import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
@@ -78,21 +61,21 @@ public class EditSessionCommandParserTest {
         assertParseFailure(parser,
                 "1" + INVALID_EXERCISE_TYPE_DESC,
                 ExerciseType.MESSAGE_CONSTRAINTS); // invalid exercise type
-        //      assertParseFailure(parser,
-        //      "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC
-        //      , Interval.MESSAGE_CONSTRAINTS); // invalid interval
-        //
-        //      // invalid gym followed by valid exercise type
-        //      assertParseFailure(parser, "1" + INVALID_GYM_DESC + VALID_EXERCISE_TYPE_MACHOMAN,
-        //      Gym.MESSAGE_CONSTRAINTS);
-        //
-        //      // valid gym followed by invalid exercise type. The test case for invalid gym followed
-        //      by valid exercise type
-        //      // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        //      assertParseFailure(parser, "1" + VALID_GYM_GETWELL + INVALID_EXERCISE_TYPE_DESC,
-        //      ExerciseType.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+          "1" + INVALID_START_TIME_DESC + INVALID_DURATION_DESC,
+                Interval.MESSAGE_DATE_TIME_CONSTRAINTS); // invalid interval
 
-        //      multiple invalid values, but only the first invalid value is captured
+        // invalid gym followed
+        assertParseFailure(parser, "1" + INVALID_GYM_DESC,
+                Gym.MESSAGE_CONSTRAINTS);
+
+        // invalid exercise type. The test case for invalid gym followed
+        // by valid exercise type
+        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
+        assertParseFailure(parser, "1" + INVALID_EXERCISE_TYPE_DESC,
+                ExerciseType.MESSAGE_CONSTRAINTS);
+
+        //multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1"
                         + INVALID_GYM_DESC + INVALID_EXERCISE_TYPE_DESC
                         + VALID_START_TIME_MACHOMAN + VALID_DURATION_GETWELL ,

--- a/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import java.time.LocalDateTime;
+
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;

--- a/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
@@ -1,8 +1,7 @@
 package seedu.address.testutil;
 
+import java.time.LocalDateTime;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.logic.parser.session.SessionParserUtil;
 import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
 import seedu.address.model.session.Interval;
@@ -52,8 +51,8 @@ public class EditSessionDescriptorBuilder {
     /**
      * Sets the {@code Interval} of the {@code EditSessionDescriptor} that we are building.
      */
-    public EditSessionDescriptorBuilder withInterval(String startTime, int duration) throws ParseException {
-        descriptor.setInterval(new Interval(SessionParserUtil.parseStringToDateTime(startTime), duration));
+    public EditSessionDescriptorBuilder withInterval(LocalDateTime startTime, int duration) {
+        descriptor.setInterval(new Interval(startTime, duration));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
@@ -8,8 +8,6 @@ import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Interval;
 import seedu.address.model.session.Session;
 
-import java.time.LocalDateTime;
-
 /**
  * A utility class to help with building EditSessionDescriptor objects.
  */
@@ -28,11 +26,11 @@ public class EditSessionDescriptorBuilder {
     /**
      * Returns an {@code EditSessionDescriptor} with fields containing {@code Session}'s details
      */
-    public EditSessionDescriptorBuilder(Session Session) {
+    public EditSessionDescriptorBuilder(Session session) {
         descriptor = new EditSessionDescriptor();
-        descriptor.setGym(Session.getGym());
-        descriptor.setExerciseType(Session.getExerciseType());
-        descriptor.setInterval(Session.getInterval());
+        descriptor.setGym(session.getGym());
+        descriptor.setExerciseType(session.getExerciseType());
+        descriptor.setInterval(session.getInterval());
     }
 
     /**
@@ -54,8 +52,8 @@ public class EditSessionDescriptorBuilder {
     /**
      * Sets the {@code Interval} of the {@code EditSessionDescriptor} that we are building.
      */
-    public EditSessionDescriptorBuilder withInterval(String start_time, int duration) throws ParseException {
-        descriptor.setInterval(new Interval(SessionParserUtil.parseStringToDateTime(start_time), duration));
+    public EditSessionDescriptorBuilder withInterval(String startTime, int duration) throws ParseException {
+        descriptor.setInterval(new Interval(SessionParserUtil.parseStringToDateTime(startTime), duration));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
@@ -1,0 +1,65 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.session.SessionParserUtil;
+import seedu.address.model.session.Gym;
+import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Interval;
+import seedu.address.model.session.Session;
+
+import java.time.LocalDateTime;
+
+/**
+ * A utility class to help with building EditSessionDescriptor objects.
+ */
+public class EditSessionDescriptorBuilder {
+
+    private EditSessionDescriptor descriptor;
+
+    public EditSessionDescriptorBuilder() {
+        descriptor = new EditSessionDescriptor();
+    }
+
+    public EditSessionDescriptorBuilder(EditSessionDescriptor descriptor) {
+        this.descriptor = new EditSessionDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditSessionDescriptor} with fields containing {@code Session}'s details
+     */
+    public EditSessionDescriptorBuilder(Session Session) {
+        descriptor = new EditSessionDescriptor();
+        descriptor.setGym(Session.getGym());
+        descriptor.setExerciseType(Session.getExerciseType());
+        descriptor.setInterval(Session.getInterval());
+    }
+
+    /**
+     * Sets the {@code Gym} of the {@code EditSessionDescriptor} that we are building.
+     */
+    public EditSessionDescriptorBuilder withGym(String gym) {
+        descriptor.setGym(new Gym(gym));
+        return this;
+    }
+
+    /**
+     * Sets the {@code ExerciseType} of the {@code EditSessionDescriptor} that we are building.
+     */
+    public EditSessionDescriptorBuilder withExerciseType(String exerciseType) {
+        descriptor.setExerciseType(new ExerciseType(exerciseType));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Interval} of the {@code EditSessionDescriptor} that we are building.
+     */
+    public EditSessionDescriptorBuilder withInterval(String start_time, int duration) throws ParseException {
+        descriptor.setInterval(new Interval(SessionParserUtil.parseStringToDateTime(start_time), duration));
+        return this;
+    }
+
+    public EditSessionDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditSessionDescriptorBuilder.java
@@ -3,8 +3,8 @@ package seedu.address.testutil;
 import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.session.SessionParserUtil;
-import seedu.address.model.session.Gym;
 import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Gym;
 import seedu.address.model.session.Interval;
 import seedu.address.model.session.Session;
 

--- a/src/test/java/seedu/address/testutil/RescheduleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/RescheduleDescriptorBuilder.java
@@ -1,9 +1,6 @@
 package seedu.address.testutil;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.model.schedule.Schedule;
-import seedu.address.model.session.ExerciseType;
-import seedu.address.model.session.Gym;
 
 import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
 
@@ -22,14 +19,14 @@ public class RescheduleDescriptorBuilder {
         this.descriptor = new RescheduleDescriptor(descriptor);
     }
 
-//    /**
-//     * Returns an {@code RescheduleDescriptorBuilder} with fields containing {@code Schedule}'s details
-//     */
-//    public RescheduleDescriptorBuilder(Schedule schedule) {
-//        descriptor = new RescheduleDescriptor();
-//        descriptor.setClientIndex(schedule.getClient());
-//        descriptor.setSessionIndex(schedule.getSession());
-//    }
+    //    /**
+    //     * Returns an {@code RescheduleDescriptorBuilder} with fields containing {@code Schedule}'s details
+    //     */
+    //    public RescheduleDescriptorBuilder(Schedule schedule) {
+    //        descriptor = new RescheduleDescriptor();
+    //        descriptor.setClientIndex(schedule.getClient());
+    //        descriptor.setSessionIndex(schedule.getSession());
+    //    }
 
     /**
      * Sets the {@code Index} of the {@code RescheduleDescriptorBuilder} that we are building.

--- a/src/test/java/seedu/address/testutil/RescheduleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/RescheduleDescriptorBuilder.java
@@ -1,7 +1,5 @@
 package seedu.address.testutil;
-
 import seedu.address.commons.core.index.Index;
-
 import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
 
 /**

--- a/src/test/java/seedu/address/testutil/RescheduleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/RescheduleDescriptorBuilder.java
@@ -1,0 +1,54 @@
+package seedu.address.testutil;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.schedule.Schedule;
+import seedu.address.model.session.ExerciseType;
+import seedu.address.model.session.Gym;
+
+import seedu.address.logic.commands.schedule.RescheduleCommand.RescheduleDescriptor;
+
+/**
+ * A utility class to help with building RescheduleDescriptorBuilder objects.
+ */
+public class RescheduleDescriptorBuilder {
+
+    private RescheduleDescriptor descriptor;
+
+    public RescheduleDescriptorBuilder() {
+        this.descriptor = new RescheduleDescriptor();
+    }
+
+    public RescheduleDescriptorBuilder(RescheduleDescriptor descriptor) {
+        this.descriptor = new RescheduleDescriptor(descriptor);
+    }
+
+//    /**
+//     * Returns an {@code RescheduleDescriptorBuilder} with fields containing {@code Schedule}'s details
+//     */
+//    public RescheduleDescriptorBuilder(Schedule schedule) {
+//        descriptor = new RescheduleDescriptor();
+//        descriptor.setClientIndex(schedule.getClient());
+//        descriptor.setSessionIndex(schedule.getSession());
+//    }
+
+    /**
+     * Sets the {@code Index} of the {@code RescheduleDescriptorBuilder} that we are building.
+     */
+    public RescheduleDescriptorBuilder withClientIndex(Index clientIndex) {
+        descriptor.setClientIndex(clientIndex);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Index} of the {@code RescheduleDescriptorBuilder} that we are building.
+     */
+    public RescheduleDescriptorBuilder withSessionIndex(Index sessionIndex) {
+        descriptor.setSessionIndex(sessionIndex);
+        return this;
+    }
+
+
+    public RescheduleDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/SessionBuilder.java
+++ b/src/test/java/seedu/address/testutil/SessionBuilder.java
@@ -61,9 +61,9 @@ public class SessionBuilder {
     /**
      * Sets the {@code Interval} of the {@code Session} that we are building.
      */
-    public SessionBuilder withInterval(String start, String duration) {
+    public SessionBuilder withInterval(String start, int duration) {
         try {
-            this.interval = new Interval(SessionParserUtil.parseStringToDateTime(start), Integer.parseInt(duration));
+            this.interval = new Interval(SessionParserUtil.parseStringToDateTime(start), duration);
             return this;
         } catch (ParseException e) {
             throw new RuntimeException(e);

--- a/src/test/java/seedu/address/testutil/SessionBuilder.java
+++ b/src/test/java/seedu/address/testutil/SessionBuilder.java
@@ -61,7 +61,7 @@ public class SessionBuilder {
     /**
      * Sets the {@code Interval} of the {@code Session} that we are building.
      */
-    public SessionBuilder withInterval(String start, int duration) {
+    public SessionBuilder withInterval(LocalDateTime start, int duration) {
         try {
             this.interval = new Interval(SessionParserUtil.parseStringToDateTime(start), duration);
             return this;

--- a/src/test/java/seedu/address/testutil/SessionBuilder.java
+++ b/src/test/java/seedu/address/testutil/SessionBuilder.java
@@ -2,8 +2,6 @@ package seedu.address.testutil;
 
 import java.time.LocalDateTime;
 
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.logic.parser.session.SessionParserUtil;
 import seedu.address.model.session.ExerciseType;
 import seedu.address.model.session.Gym;
 import seedu.address.model.session.Interval;
@@ -62,12 +60,8 @@ public class SessionBuilder {
      * Sets the {@code Interval} of the {@code Session} that we are building.
      */
     public SessionBuilder withInterval(LocalDateTime start, int duration) {
-        try {
-            this.interval = new Interval(SessionParserUtil.parseStringToDateTime(start), duration);
-            return this;
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
+        this.interval = new Interval(start, duration);
+        return this;
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -13,4 +13,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_SESSION = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_SESSION = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_SESSION = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_SCHEDULE = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_SCHEDULE = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_SCHEDULE = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_CLIENT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_CLIENT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_CLIENT = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_SESSION = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_SESSION = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_SESSION = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/address/testutil/TypicalSessions.java
+++ b/src/test/java/seedu/address/testutil/TypicalSessions.java
@@ -26,14 +26,14 @@ public class TypicalSessions {
     public static final Session GETWELL = new SessionBuilder()
             .withGym(VALID_GYM_GETWELL)
             .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-            .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER)
-                    , Integer.parseInt(VALID_DURATION_GETWELL))
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER),
+                    Integer.parseInt(VALID_DURATION_GETWELL))
             .build();
     public static final Session MACHOMAN = new SessionBuilder()
             .withGym(VALID_GYM_MACHOMAN)
             .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-            .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
-                    , Integer.parseInt(VALID_DURATION_MACHOMAN))
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER),
+                    Integer.parseInt(VALID_DURATION_MACHOMAN))
             .build();
 
     private TypicalSessions() {

--- a/src/test/java/seedu/address/testutil/TypicalSessions.java
+++ b/src/test/java/seedu/address/testutil/TypicalSessions.java
@@ -9,10 +9,12 @@ import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_
 import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_GETWELL;
 import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_START_TIME_MACHOMAN;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.session.Interval;
 import seedu.address.model.session.Session;
 
 /**
@@ -24,12 +26,14 @@ public class TypicalSessions {
     public static final Session GETWELL = new SessionBuilder()
             .withGym(VALID_GYM_GETWELL)
             .withExerciseType(VALID_EXERCISE_TYPE_GETWELL)
-            .withInterval(VALID_START_TIME_GETWELL, VALID_DURATION_GETWELL)
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_GETWELL, Interval.DATE_TIME_FORMATTER)
+                    , Integer.parseInt(VALID_DURATION_GETWELL))
             .build();
     public static final Session MACHOMAN = new SessionBuilder()
             .withGym(VALID_GYM_MACHOMAN)
             .withExerciseType(VALID_EXERCISE_TYPE_MACHOMAN)
-            .withInterval(VALID_START_TIME_MACHOMAN, VALID_DURATION_MACHOMAN)
+            .withInterval(LocalDateTime.parse(VALID_START_TIME_MACHOMAN, Interval.DATE_TIME_FORMATTER)
+                    , Integer.parseInt(VALID_DURATION_MACHOMAN))
             .build();
 
     private TypicalSessions() {


### PR DESCRIPTION
Some things to take note:

1. Command has been changed from "[c/CLIENT] [s/SESSION]" to "[INDEX] [s/SESSION]" which makes more sense.

2. 1 issue which is that when the input session is higher than the total number of session, there's an exception on the terminal but nothing is being printed on FitEgo. The issue is with RescheduleCommand only having the [INDEX] which takes care of the problem when [INDEX] > total schedules, but in Parser, I'm not able to retrieve the filteredSessionList as it requires Model to retrieve it, so FitEgo can't detect the issue when input session is higher than total sessions.

3. Testing for this Reschedule is not fully up yet because there isn't a ScheduleCommandTestUtil class, not sure if this is required because now it's a bit tricky in a sense that Schedule contains Client and Session while RescheduleDescriptor contains clientIndex and sessionIndex of Index class. If RescheduleDescriptor were to contain Client and Session, it should be easier but in RescheduleCommandParser, similar to issue 2 above, I'm not able to retrieve the filteredSessionList as it requires Model to retrieve it.