### PR TITLE
Delete session command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/session/DeleteSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/session/DeleteSessionCommand.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands.session;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.session.Session;
+
+/**
+ * Deletes a Session identified using it's displayed index from the address book.
+ */
+public class DeleteSessionCommand extends Command {
+
+    public static final String COMMAND_WORD = "sdel";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the Session identified by the index number used in the displayed Session list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_SESSION_SUCCESS = "Deleted Session: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteSessionCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Session> lastShownList = model.getFilteredSessionList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+        }
+
+        Session sessionToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteSession(sessionToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_SESSION_SUCCESS, sessionToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteSessionCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteSessionCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.client.ViewClientCommand;
 import seedu.address.logic.commands.schedule.AddScheduleCommand;
 import seedu.address.logic.commands.schedule.RescheduleCommand;
 import seedu.address.logic.commands.session.AddSessionCommand;
+import seedu.address.logic.commands.session.DeleteSessionCommand;
 import seedu.address.logic.commands.session.EditSessionCommand;
 import seedu.address.logic.parser.client.AddClientCommandParser;
 import seedu.address.logic.parser.client.DeleteClientCommandParser;
@@ -31,6 +32,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.schedule.AddScheduleCommandParser;
 import seedu.address.logic.parser.schedule.RescheduleCommandParser;
 import seedu.address.logic.parser.session.AddSessionCommandParser;
+import seedu.address.logic.parser.session.DeleteSessionCommandParser;
 import seedu.address.logic.parser.session.EditSessionCommandParser;
 
 /**
@@ -67,6 +69,7 @@ public class AddressBookParser {
         //Session-Related Commands
         commandMapper.put(AddSessionCommand.COMMAND_WORD, (args) -> new AddSessionCommandParser().parse(args));
         commandMapper.put(EditSessionCommand.COMMAND_WORD, (args) -> new EditSessionCommandParser().parse(args));
+        commandMapper.put(DeleteSessionCommand.COMMAND_WORD, (args) -> new DeleteSessionCommandParser().parse(args));
 
         //Schedule-Related Commands
         commandMapper.put(AddScheduleCommand.COMMAND_WORD, (args) -> new AddScheduleCommandParser().parse(args));

--- a/src/main/java/seedu/address/logic/parser/session/DeleteSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/DeleteSessionCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser.session;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.session.DeleteSessionCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteSessionCommand object
+ */
+public class DeleteSessionCommandParser implements Parser<DeleteSessionCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteSessionCommand
+     * and returns a DeleteSessionCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteSessionCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteSessionCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteSessionCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/session/IntervalContainsDatetimePredicate.java
+++ b/src/main/java/seedu/address/model/session/IntervalContainsDatetimePredicate.java
@@ -1,0 +1,25 @@
+package seedu.address.model.session;
+
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+public class IntervalContainsDatetimePredicate implements Predicate<Session> {
+    private final LocalDateTime datetime;
+
+    public IntervalContainsDatetimePredicate(LocalDateTime datetime) {
+        this.datetime = datetime;
+    }
+
+    @Override
+    public boolean test(Session session) {
+        Interval sessionInterval = session.getInterval();
+        return !datetime.isBefore(sessionInterval.getStart()) && !datetime.isAfter(sessionInterval.getEnd());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof IntervalContainsDatetimePredicate // instanceof handles nulls
+                && datetime.equals(((IntervalContainsDatetimePredicate) other).datetime)); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/session/DeleteSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/DeleteSessionCommandTest.java
@@ -1,0 +1,110 @@
+package seedu.address.logic.commands.session;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.session.SessionCommandTestUtil.showSessionAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SESSION;
+import static seedu.address.testutil.TypicalSessions.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.session.Session;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteClientCommand}.
+ */
+public class DeleteSessionCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Session sessionToDelete = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+        DeleteSessionCommand deleteSessionCommand = new DeleteSessionCommand(INDEX_FIRST_SESSION);
+
+        String expectedMessage = String.format(DeleteSessionCommand.MESSAGE_DELETE_SESSION_SUCCESS, sessionToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteSession(sessionToDelete);
+
+        assertCommandSuccess(deleteSessionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredSessionList().size() + 1);
+        DeleteSessionCommand deleteSessionCommand = new DeleteSessionCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+
+        Session sessionToDelete = model.getFilteredSessionList().get(INDEX_FIRST_SESSION.getZeroBased());
+        DeleteSessionCommand deleteSessionCommand = new DeleteSessionCommand(INDEX_FIRST_SESSION);
+
+        String expectedMessage = String.format(DeleteSessionCommand.MESSAGE_DELETE_SESSION_SUCCESS, sessionToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteSession(sessionToDelete);
+        showNoSession(expectedModel);
+
+        assertCommandSuccess(deleteSessionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showSessionAtIndex(model, INDEX_FIRST_SESSION);
+
+        Index outOfBoundIndex = INDEX_SECOND_SESSION;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getSessionList().size());
+
+        DeleteSessionCommand deleteSessionCommand = new DeleteSessionCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteSessionCommand, model, Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteSessionCommand deleteFirstCommand = new DeleteSessionCommand(INDEX_FIRST_SESSION);
+        DeleteSessionCommand deleteSecondCommand = new DeleteSessionCommand(INDEX_SECOND_SESSION);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteSessionCommand deleteFirstCommandCopy = new DeleteSessionCommand(INDEX_FIRST_SESSION);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different Session -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoSession(Model model) {
+        model.updateFilteredSessionList(p -> false);
+
+        assertTrue(model.getFilteredSessionList().isEmpty());
+    }
+}
+

--- a/src/test/java/seedu/address/logic/commands/session/DeleteSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/session/DeleteSessionCommandTest.java
@@ -20,7 +20,7 @@ import seedu.address.model.session.Session;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code DeleteClientCommand}.
+ * {@code DeleteSessionCommand}.
  */
 public class DeleteSessionCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/session/SessionCommandTestUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_EXERCISE_TYPE;
 import static seedu.address.logic.parser.session.CliSyntax.PREFIX_GYM;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -18,6 +20,7 @@ import seedu.address.logic.commands.session.EditSessionCommand.EditSessionDescri
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.session.Interval;
+import seedu.address.model.session.IntervalContainsDatetimePredicate;
 import seedu.address.model.session.Session;
 import seedu.address.testutil.EditSessionDescriptorBuilder;
 
@@ -110,17 +113,17 @@ public class SessionCommandTestUtil {
         assertEquals(expectedFilteredList, actualModel.getFilteredSessionList());
     }
 
-    //    /**
-    //     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
-    //     * {@code model}'s address book.
-    //    */
-    //    public static void showSessionAtIndex(Model model, Index targetIndex) {
-    //        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
-    //
-    //        Session session = model.getFilteredSessionList().get(targetIndex.getZeroBased());
-    //        final String[] splitName = session.getName().fullName.split("\\s+");
-    //        model.updateFilteredSessionList(new NameContainsSubstringPredicate(Arrays.asList(splitName[0])));
-    //
-    //        assertEquals(1, model.getFilteredSessionList().size());
-    //  }
+    /**
+     * Updates {@code model}'s filtered list to show only the Session at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showSessionAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredSessionList().size());
+
+        Session session = model.getFilteredSessionList().get(targetIndex.getZeroBased());
+        final LocalDateTime start = session.getInterval().getStart();
+        model.updateFilteredSessionList(new IntervalContainsDatetimePredicate(start));
+
+        assertEquals(1, model.getFilteredSessionList().size());
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/session/DeleteSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/session/DeleteSessionCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser.session;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.session.DeleteSessionCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the SessionParserUtil, and
+ * therefore should be covered by the SessionParserUtilTest.
+ */
+public class DeleteSessionCommandParserTest {
+
+    private DeleteSessionCommandParser parser = new DeleteSessionCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DeleteSessionCommand(INDEX_FIRST_SESSION));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteSessionCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalSessions.java
+++ b/src/test/java/seedu/address/testutil/TypicalSessions.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.commands.session.SessionCommandTestUtil.VALID_
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
@@ -51,6 +52,6 @@ public class TypicalSessions {
     }
 
     public static List<Session> getTypicalSessions() {
-        return new ArrayList<>();
+        return new ArrayList<>(Arrays.asList(GETWELL, MACHOMAN));
     }
 }


### PR DESCRIPTION
Closes #36 

Add implementation + tests for DeleteSessionCommand similar to DeleteClientCommand

Keyword: `sdel`

Notes:
- Deleting session might leave a scheduled schedule without a corresponding session (will fix in #98 )