### PR TITLE
Update schedule equality method

### DIFF
--- a/src/main/java/seedu/address/model/schedule/Schedule.java
+++ b/src/main/java/seedu/address/model/schedule/Schedule.java
@@ -59,7 +59,7 @@ public class Schedule implements CheckExisting<Schedule> {
         }
 
         Schedule otherSchedule = (Schedule) other;
-        return otherSchedule.client.equals(this.client) && otherSchedule.session == this.session;
+        return otherSchedule.client.equals(this.client) && otherSchedule.session.equals(this.session);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/session/Session.java
+++ b/src/main/java/seedu/address/model/session/Session.java
@@ -97,10 +97,10 @@ public class Session implements CheckExisting<Session> {
             return false;
         }
 
-        Session otherClient = (Session) other;
-        return otherClient.getGym().equals(getGym())
-                && otherClient.getInterval().equals(getInterval())
-                && otherClient.getExerciseType().equals(getExerciseType());
+        Session otherSession = (Session) other;
+        return otherSession.getGym().equals(getGym())
+                && otherSession.getInterval().equals(getInterval())
+                && otherSession.getExerciseType().equals(getExerciseType());
     }
 
     @Override


### PR DESCRIPTION
Schedule's equals was not using session's equals method but instead ==
Also changed the equals method in Session to name the other object as otherSession instead of otherClient
Found the above issues when execute_scheduleAcceptedByModel_addSuccessful() was failing on my schedule-card branch